### PR TITLE
Add the packaging metadata to build the nheko snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: nheko
+version: master
+summary: Desktop client for the Matrix protocol
+description: |
+  The motivation behind the project is to provide a native desktop app for
+  Matrix that feels more like a mainstream chat app (Riot, Telegram etc) and
+  less like an IRC client.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict
+
+apps:
+  nheko:
+    command: desktop-launch $SNAP/nheko
+    plugs: [network, network-bind, x11, unity7, home]
+
+parts:
+  nheko:
+    source: .
+    plugin: cmake
+    build-packages: [gcc]
+    artifacts: [nheko]
+    after: [desktop-qt5]


### PR DESCRIPTION
This package will let you publish the latest nheko in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress.