### PR TITLE
Fix emoji alignment issue

### DIFF
--- a/src/EmojiItemDelegate.cc
+++ b/src/EmojiItemDelegate.cc
@@ -43,5 +43,5 @@ void EmojiItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opt
 	font.setPixelSize(19);
 
 	painter->setFont(font);
-	painter->drawText(viewOption.rect, emoji);
+	painter->drawText(viewOption.rect, Qt::AlignCenter, emoji);
 }


### PR DESCRIPTION
Without the flag, the emoji were being drawn off-center, leading to them getting slightly clipped in some places or going out of bounds in others. It isn't too obvious right now, but it becomes obvious if you add a background on hover.
Here are some screenshots to show the difference:
![image](https://user-images.githubusercontent.com/12787230/27842277-3840f798-6111-11e7-99ad-f621bba6db8f.png)
![image](https://user-images.githubusercontent.com/12787230/27842281-3c89ddd8-6111-11e7-956f-bb0b342fdc58.png)
