### PR TITLE
Ctrl-Q from the main window quits the application

### DIFF
--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -87,7 +87,7 @@ MainWindow::MainWindow(QWidget *parent)
                 SLOT(showChatPage(QString, QString, QString)));
 
         QShortcut *quitShortcut = new QShortcut(QKeySequence::Quit, this);
-        connect(quitShortcut, &QShortcut::activated, this, [=]() { QApplication::quit(); });
+        connect(quitShortcut, &QShortcut::activated, this, QApplication::quit);
 
         QSettings settings;
 

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -22,6 +22,8 @@
 #include <QNetworkReply>
 #include <QSettings>
 #include <QSystemTrayIcon>
+#include <QShortcut>
+#include <QApplication>
 
 MainWindow *MainWindow::instance_ = nullptr;
 
@@ -83,6 +85,9 @@ MainWindow::MainWindow(QWidget *parent)
                 SIGNAL(loginSuccess(QString, QString, QString)),
                 this,
                 SLOT(showChatPage(QString, QString, QString)));
+
+        QShortcut *quitShortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q), this);
+        connect(quitShortcut, &QShortcut::activated, this, [=]() { QApplication::quit(); });
 
         QSettings settings;
 

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -86,7 +86,7 @@ MainWindow::MainWindow(QWidget *parent)
                 this,
                 SLOT(showChatPage(QString, QString, QString)));
 
-        QShortcut *quitShortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q), this);
+        QShortcut *quitShortcut = new QShortcut(QKeySequence::Quit, this);
         connect(quitShortcut, &QShortcut::activated, this, [=]() { QApplication::quit(); });
 
         QSettings settings;

--- a/src/TrayIcon.cc
+++ b/src/TrayIcon.cc
@@ -87,7 +87,7 @@ TrayIcon::TrayIcon(const QString &filename, QWidget *parent)
         quitAction_ = new QAction(tr("Quit"), parent);
 
         connect(viewAction_, SIGNAL(triggered()), parent, SLOT(show()));
-        connect(quitAction_, &QAction::triggered, this, [=]() { QApplication::quit(); });
+        connect(quitAction_, &QAction::triggered, this, QApplication::quit);
 
         menu->addAction(viewAction_);
         menu->addAction(quitAction_);


### PR DESCRIPTION
Fixes #61.

I've only tested this on my laptop running Fedora, but it seems simple enough.
Does macOS and its Command key need to be separately handled?