### PR TITLE
React to externally left and joined rooms, and add "leave room" button in room menu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ set(SRC_FILES
     src/TimelineViewManager.cc
     src/InputValidator.cc
     src/JoinRoomDialog.cc
+    src/LeaveRoomDialog.cc
     src/Login.cc
     src/LoginPage.cc
     src/LogoutDialog.cc
@@ -208,6 +209,7 @@ qt5_wrap_cpp(MOC_HEADERS
     include/TimelineItem.h
     include/TimelineView.h
     include/TimelineViewManager.h
+    include/LeaveRoomDialog.h
     include/LoginPage.h
     include/LogoutDialog.h
     include/MainWindow.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,7 @@ set(SRC_FILES
     src/TimelineView.cc
     src/TimelineViewManager.cc
     src/InputValidator.cc
+    src/JoinRoomDialog.cc
     src/Login.cc
     src/LoginPage.cc
     src/LogoutDialog.cc
@@ -203,6 +204,7 @@ qt5_wrap_cpp(MOC_HEADERS
     include/EmojiPickButton.h
     include/ImageItem.h
     include/ImageOverlayDialog.h
+    include/JoinRoomDialog.h
     include/TimelineItem.h
     include/TimelineView.h
     include/TimelineViewManager.h

--- a/include/Cache.h
+++ b/include/Cache.h
@@ -37,6 +37,8 @@ public:
         inline void unmount();
         inline QString memberDbName(const QString &roomid);
 
+        void removeRoom(const QString &roomid);
+
 private:
         void setNextBatchToken(lmdb::txn &txn, const QString &token);
         void insertRoomState(lmdb::txn &txn, const QString &roomid, const RoomState &state);

--- a/include/ChatPage.h
+++ b/include/ChatPage.h
@@ -61,8 +61,8 @@ private slots:
         void changeTopRoomInfo(const QString &room_id);
         void startSync();
         void logout();
-        void joinedRoom(const QString &room_id);
-        void leftRoom(const QString &room_id);
+        void addRoom(const QString &room_id);
+        void removeRoom(const QString &room_id);
 
 protected:
         void keyPressEvent(QKeyEvent *event) override;

--- a/include/ChatPage.h
+++ b/include/ChatPage.h
@@ -61,6 +61,8 @@ private slots:
         void changeTopRoomInfo(const QString &room_id);
         void startSync();
         void logout();
+        void joinedRoom(const QString &room_id);
+        void leftRoom(const QString &room_id);
 
 protected:
         void keyPressEvent(QKeyEvent *event) override;

--- a/include/JoinRoomDialog.h
+++ b/include/JoinRoomDialog.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <QFrame>
+#include <QLineEdit>
+
+#include "FlatButton.h"
+
+class JoinRoomDialog : public QFrame
+{
+        Q_OBJECT
+public:
+        JoinRoomDialog(QWidget *parent = nullptr);
+
+signals:
+        void closing(bool isJoining, QString roomAlias);
+
+private:
+        FlatButton *confirmBtn_;
+        FlatButton *cancelBtn_;
+
+        QLineEdit *roomAliasEdit_;
+};

--- a/include/LeaveRoomDialog.h
+++ b/include/LeaveRoomDialog.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <QFrame>
+
+#include "FlatButton.h"
+
+class LeaveRoomDialog : public QFrame
+{
+        Q_OBJECT
+public:
+        explicit LeaveRoomDialog(QWidget *parent = nullptr);
+
+signals:
+        void closing(bool isLeaving);
+
+private:
+        FlatButton *confirmBtn_;
+        FlatButton *cancelBtn_;
+};

--- a/include/MatrixClient.h
+++ b/include/MatrixClient.h
@@ -52,6 +52,7 @@ public:
         void downloadImage(const QString &event_id, const QUrl &url);
         void messages(const QString &room_id, const QString &from_token, int limit = 20) noexcept;
         void uploadImage(const QString &roomid, const QString &filename);
+        void joinRoom(const QString &roomIdOrAlias);
 
         inline QUrl getHomeServer();
         inline int transactionId();
@@ -94,6 +95,7 @@ signals:
         void messageSent(const QString &event_id, const QString &roomid, const int txn_id);
         void emoteSent(const QString &event_id, const QString &roomid, const int txn_id);
         void messagesRetrieved(const QString &room_id, const RoomMessages &msgs);
+        void joinedRoom(const QString &room_id);
 
 private slots:
         void onResponse(QNetworkReply *reply);
@@ -115,6 +117,7 @@ private:
                 Sync,
                 UserAvatar,
                 Versions,
+                JoinRoom,
         };
 
         // Response handlers.
@@ -132,6 +135,7 @@ private:
         void onSyncResponse(QNetworkReply *reply);
         void onUserAvatarResponse(QNetworkReply *reply);
         void onVersionsResponse(QNetworkReply *reply);
+        void onJoinRoomResponse(QNetworkReply *reply);
 
         // Client API prefix.
         QString clientApiUrl_;

--- a/include/MatrixClient.h
+++ b/include/MatrixClient.h
@@ -53,6 +53,7 @@ public:
         void messages(const QString &room_id, const QString &from_token, int limit = 20) noexcept;
         void uploadImage(const QString &roomid, const QString &filename);
         void joinRoom(const QString &roomIdOrAlias);
+        void leaveRoom(const QString &roomId);
 
         inline QUrl getHomeServer();
         inline int transactionId();
@@ -96,6 +97,7 @@ signals:
         void emoteSent(const QString &event_id, const QString &roomid, const int txn_id);
         void messagesRetrieved(const QString &room_id, const RoomMessages &msgs);
         void joinedRoom(const QString &room_id);
+        void leftRoom(const QString &room_id);
 
 private slots:
         void onResponse(QNetworkReply *reply);
@@ -118,6 +120,7 @@ private:
                 UserAvatar,
                 Versions,
                 JoinRoom,
+                LeaveRoom,
         };
 
         // Response handlers.
@@ -136,6 +139,7 @@ private:
         void onUserAvatarResponse(QNetworkReply *reply);
         void onVersionsResponse(QNetworkReply *reply);
         void onJoinRoomResponse(QNetworkReply *reply);
+        void onLeaveRoomResponse(QNetworkReply *reply);
 
         // Client API prefix.
         QString clientApiUrl_;

--- a/include/RoomInfoListItem.h
+++ b/include/RoomInfoListItem.h
@@ -57,6 +57,7 @@ public:
 
 signals:
         void clicked(const QString &room_id);
+        void leaveRoom(const QString &room_id);
 
 public slots:
         void setPressedState(bool state);
@@ -86,6 +87,7 @@ private:
 
         Menu *menu_;
         QAction *toggleNotifications_;
+        QAction *leaveRoom_;
 
         QSharedPointer<RoomSettings> roomSettings_;
 

--- a/include/RoomList.h
+++ b/include/RoomList.h
@@ -44,6 +44,9 @@ public:
 
         void clear();
 
+        void addRoom(const QSharedPointer<RoomSettings> &settings,
+                     const RoomState &state,
+                     const QString &room_id);
         void removeRoom(const QString &room_id, bool reset);
 
 signals:

--- a/include/RoomList.h
+++ b/include/RoomList.h
@@ -60,6 +60,7 @@ public slots:
         void updateUnreadMessageCount(const QString &roomid, int count);
         void updateRoomDescription(const QString &roomid, const DescInfo &info);
         void closeJoinRoomDialog(bool isJoining, QString roomAlias);
+        void openLeaveRoomDialog(const QString &room_id);
         void closeLeaveRoomDialog(bool leaving, const QString &room_id);
 
 private:

--- a/include/RoomList.h
+++ b/include/RoomList.h
@@ -24,6 +24,7 @@
 #include <QWidget>
 
 #include "JoinRoomDialog.h"
+#include "LeaveRoomDialog.h"
 #include "MatrixClient.h"
 #include "OverlayModal.h"
 #include "RoomInfoListItem.h"
@@ -59,6 +60,7 @@ public slots:
         void updateUnreadMessageCount(const QString &roomid, int count);
         void updateRoomDescription(const QString &roomid, const DescInfo &info);
         void closeJoinRoomDialog(bool isJoining, QString roomAlias);
+        void closeLeaveRoomDialog(bool leaving, const QString &room_id);
 
 private:
         void calculateUnreadMessageCount();
@@ -72,6 +74,9 @@ private:
 
         OverlayModal *joinRoomModal_;
         JoinRoomDialog *joinRoomDialog_;
+
+        OverlayModal *leaveRoomModal;
+        LeaveRoomDialog *leaveRoomDialog_;
 
         QMap<QString, QSharedPointer<RoomInfoListItem>> rooms_;
 

--- a/include/RoomList.h
+++ b/include/RoomList.h
@@ -17,18 +17,18 @@
 
 #pragma once
 
+#include <QPushButton>
 #include <QScrollArea>
 #include <QSharedPointer>
 #include <QVBoxLayout>
 #include <QWidget>
-#include <QPushButton>
 
+#include "JoinRoomDialog.h"
 #include "MatrixClient.h"
+#include "OverlayModal.h"
 #include "RoomInfoListItem.h"
 #include "RoomState.h"
 #include "Sync.h"
-#include "OverlayModal.h"
-#include "JoinRoomDialog.h"
 
 class RoomList : public QWidget
 {

--- a/include/RoomList.h
+++ b/include/RoomList.h
@@ -44,6 +44,8 @@ public:
 
         void clear();
 
+        void removeRoom(const QString &room_id, bool reset);
+
 signals:
         void roomChanged(const QString &room_id);
         void totalUnreadMessageCountUpdated(int count);
@@ -53,8 +55,6 @@ public slots:
         void highlightSelectedRoom(const QString &room_id);
         void updateUnreadMessageCount(const QString &roomid, int count);
         void updateRoomDescription(const QString &roomid, const DescInfo &info);
-
-private slots:
         void closeJoinRoomDialog(bool isJoining, QString roomAlias);
 
 private:

--- a/include/RoomList.h
+++ b/include/RoomList.h
@@ -21,11 +21,14 @@
 #include <QSharedPointer>
 #include <QVBoxLayout>
 #include <QWidget>
+#include <QPushButton>
 
 #include "MatrixClient.h"
 #include "RoomInfoListItem.h"
 #include "RoomState.h"
 #include "Sync.h"
+#include "OverlayModal.h"
+#include "JoinRoomDialog.h"
 
 class RoomList : public QWidget
 {
@@ -51,6 +54,9 @@ public slots:
         void updateUnreadMessageCount(const QString &roomid, int count);
         void updateRoomDescription(const QString &roomid, const DescInfo &info);
 
+private slots:
+        void closeJoinRoomDialog(bool isJoining, QString roomAlias);
+
 private:
         void calculateUnreadMessageCount();
 
@@ -58,6 +64,11 @@ private:
         QVBoxLayout *contentsLayout_;
         QScrollArea *scrollArea_;
         QWidget *scrollAreaContents_;
+
+        QPushButton *joinRoomButton_;
+
+        OverlayModal *joinRoomModal_;
+        JoinRoomDialog *joinRoomDialog_;
 
         QMap<QString, QSharedPointer<RoomInfoListItem>> rooms_;
 

--- a/include/Sync.h
+++ b/include/Sync.h
@@ -171,21 +171,54 @@ JoinedRoom::timeline() const
         return timeline_;
 }
 
+class LeftRoom : public Deserializable
+{
+public:
+        inline State state() const;
+        inline Timeline timeline() const;
+
+        void deserialize(const QJsonValue &data) override;
+
+private:
+        State state_;
+        Timeline timeline_;
+};
+
+inline State
+LeftRoom::state() const
+{
+        return state_;
+}
+
+inline Timeline
+LeftRoom::timeline() const
+{
+        return timeline_;
+}
+
 // TODO: Add support for invited and left rooms.
 class Rooms : public Deserializable
 {
 public:
         inline QMap<QString, JoinedRoom> join() const;
+        inline QMap<QString, LeftRoom> leave() const;
         void deserialize(const QJsonValue &data) override;
 
 private:
         QMap<QString, JoinedRoom> join_;
+        QMap<QString, LeftRoom> leave_;
 };
 
 inline QMap<QString, JoinedRoom>
 Rooms::join() const
 {
         return join_;
+}
+
+inline QMap<QString, LeftRoom>
+Rooms::leave() const
+{
+        return leave_;
 }
 
 class SyncResponse : public Deserializable

--- a/include/TimelineViewManager.h
+++ b/include/TimelineViewManager.h
@@ -40,6 +40,10 @@ public:
         void initialize(const Rooms &rooms);
         // Empty initialization.
         void initialize(const QList<QString> &rooms);
+
+        void addRoom(const JoinedRoom &room, const QString &room_id);
+        void addRoom(const QString &room_id);
+
         void sync(const Rooms &rooms);
         void clearAll();
 

--- a/include/TopRoomBar.h
+++ b/include/TopRoomBar.h
@@ -29,7 +29,9 @@
 
 #include "Avatar.h"
 #include "FlatButton.h"
+#include "LeaveRoomDialog.h"
 #include "Menu.h"
+#include "OverlayModal.h"
 #include "RoomSettings.h"
 
 static const QString URL_HTML = "<a href=\"\\1\" style=\"color: #333333\">\\1</a>";
@@ -57,6 +59,9 @@ signals:
 protected:
         void paintEvent(QPaintEvent *event) override;
 
+private slots:
+        void closeLeaveRoomDialog(bool leaving);
+
 private:
         QHBoxLayout *topLayout_;
         QVBoxLayout *textLayout_;
@@ -71,6 +76,9 @@ private:
         QAction *leaveRoom_;
 
         FlatButton *settingsBtn_;
+
+        OverlayModal *leaveRoomModal;
+        LeaveRoomDialog *leaveRoomDialog_;
 
         Avatar *avatar_;
 

--- a/include/TopRoomBar.h
+++ b/include/TopRoomBar.h
@@ -51,6 +51,9 @@ public:
 
         void reset();
 
+signals:
+        void leaveRoom();
+
 protected:
         void paintEvent(QPaintEvent *event) override;
 
@@ -65,6 +68,7 @@ private:
 
         QMenu *menu_;
         QAction *toggleNotifications_;
+        QAction *leaveRoom_;
 
         FlatButton *settingsBtn_;
 

--- a/src/Cache.cc
+++ b/src/Cache.cc
@@ -153,6 +153,19 @@ Cache::insertRoomState(lmdb::txn &txn, const QString &roomid, const RoomState &s
         }
 }
 
+void
+Cache::removeRoom(const QString &roomid)
+{
+    auto txn = lmdb::txn::begin(env_, nullptr, 0);
+
+    lmdb::dbi_del(txn,
+                  roomDb_,
+                  lmdb::val(roomid.toUtf8(), roomid.toUtf8().size()),
+                  nullptr);
+
+    txn.commit();
+}
+
 QMap<QString, RoomState>
 Cache::states()
 {

--- a/src/Cache.cc
+++ b/src/Cache.cc
@@ -156,14 +156,11 @@ Cache::insertRoomState(lmdb::txn &txn, const QString &roomid, const RoomState &s
 void
 Cache::removeRoom(const QString &roomid)
 {
-    auto txn = lmdb::txn::begin(env_, nullptr, 0);
+        auto txn = lmdb::txn::begin(env_, nullptr, 0);
 
-    lmdb::dbi_del(txn,
-                  roomDb_,
-                  lmdb::val(roomid.toUtf8(), roomid.toUtf8().size()),
-                  nullptr);
+        lmdb::dbi_del(txn, roomDb_, lmdb::val(roomid.toUtf8(), roomid.toUtf8().size()), nullptr);
 
-    txn.commit();
+        txn.commit();
 }
 
 QMap<QString, RoomState>

--- a/src/ChatPage.cc
+++ b/src/ChatPage.cc
@@ -114,6 +114,10 @@ ChatPage::ChatPage(QSharedPointer<MatrixClient> client, QWidget *parent)
         connect(user_info_widget_, SIGNAL(logout()), client_.data(), SLOT(logout()));
         connect(client_.data(), SIGNAL(loggedOut()), this, SLOT(logout()));
 
+        connect(top_bar_, &TopRoomBar::leaveRoom, this, [=](){
+            client_->leaveRoom(current_room_);
+        });
+
         connect(room_list_, &RoomList::roomChanged, this, &ChatPage::changeTopRoomInfo);
         connect(room_list_, &RoomList::roomChanged, text_input_, &TextInputWidget::focusLineEdit);
         connect(
@@ -190,6 +194,14 @@ ChatPage::ChatPage(QSharedPointer<MatrixClient> client, QWidget *parent)
                 SIGNAL(ownAvatarRetrieved(const QPixmap &)),
                 this,
                 SLOT(setOwnAvatar(const QPixmap &)));
+        connect(client_.data(),
+                SIGNAL(joinedRoom(const QString &)),
+                this,
+                SLOT(joinedRoom(const QString &)));
+        connect(client_.data(),
+                SIGNAL(leftRoom(const QString &)),
+                this,
+                SLOT(leftRoom(const QString &)));
 
         AvatarProvider::init(client);
 }
@@ -307,11 +319,20 @@ ChatPage::syncCompleted(const SyncResponse &response)
                         oldState.update(room_state);
                         state_manager_.insert(it.key(), oldState);
                 } else {
+                        // TODO: Add newly joined room
                         qWarning() << "New rooms cannot be added after initial sync, yet.";
                 }
 
                 if (it.key() == current_room_)
                         changeTopRoomInfo(it.key());
+        }
+
+        auto leave = response.rooms().leave();
+
+        for (auto it = leave.constBegin(); it != leave.constEnd(); it++) {
+            if (state_manager_.contains(it.key())) {
+                leftRoom(it.key());
+            }
         }
 
         try {
@@ -535,6 +556,33 @@ ChatPage::showQuickSwitcher()
 
         quickSwitcher_->setRoomList(rooms);
         quickSwitcherModal_->fadeIn();
+}
+
+void
+ChatPage::joinedRoom(const QString &room_id)
+{
+    RoomState room_state;
+
+    state_manager_.insert(room_id, room_state);
+    settingsManager_.insert(room_id,
+                            QSharedPointer<RoomSettings>(new RoomSettings(room_id)));
+
+    this->changeTopRoomInfo(room_id);
+}
+
+void
+ChatPage::leftRoom(const QString &room_id)
+{
+    state_manager_.remove(room_id);
+    settingsManager_.remove(room_id);
+    try {
+        cache_->removeRoom(room_id);
+    } catch (const lmdb::error &e) {
+        qCritical() << "The cache couldn't be updated: " << e.what();
+        // TODO: Notify the user.
+        cache_->unmount();
+    }
+    room_list_->removeRoom(room_id, room_id == current_room_);
 }
 
 ChatPage::~ChatPage()

--- a/src/ChatPage.cc
+++ b/src/ChatPage.cc
@@ -114,14 +114,13 @@ ChatPage::ChatPage(QSharedPointer<MatrixClient> client, QWidget *parent)
         connect(user_info_widget_, SIGNAL(logout()), client_.data(), SLOT(logout()));
         connect(client_.data(), SIGNAL(loggedOut()), this, SLOT(logout()));
 
-        connect(top_bar_, &TopRoomBar::leaveRoom, this, [=](){
-            client_->leaveRoom(current_room_);
-        });
+        connect(
+          top_bar_, &TopRoomBar::leaveRoom, this, [=]() { client_->leaveRoom(current_room_); });
 
         connect(room_list_, &RoomList::roomChanged, this, &ChatPage::changeTopRoomInfo);
         connect(room_list_, &RoomList::roomChanged, text_input_, &TextInputWidget::focusLineEdit);
         connect(
-            room_list_, &RoomList::roomChanged, view_manager_, &TimelineViewManager::setHistoryView);
+          room_list_, &RoomList::roomChanged, view_manager_, &TimelineViewManager::setHistoryView);
 
         connect(view_manager_,
                 &TimelineViewManager::unreadMessages,
@@ -198,10 +197,8 @@ ChatPage::ChatPage(QSharedPointer<MatrixClient> client, QWidget *parent)
                 SIGNAL(joinedRoom(const QString &)),
                 this,
                 SLOT(joinedRoom(const QString &)));
-        connect(client_.data(),
-                SIGNAL(leftRoom(const QString &)),
-                this,
-                SLOT(leftRoom(const QString &)));
+        connect(
+          client_.data(), SIGNAL(leftRoom(const QString &)), this, SLOT(leftRoom(const QString &)));
 
         AvatarProvider::init(client);
 }
@@ -336,19 +333,18 @@ ChatPage::syncCompleted(const SyncResponse &response)
                         updateDisplayNames(room_state);
 
                         state_manager_.insert(it.key(), room_state);
-                        settingsManager_.insert(it.key(),
-                                    QSharedPointer<RoomSettings>(new RoomSettings(it.key())));
+                        settingsManager_.insert(
+                          it.key(), QSharedPointer<RoomSettings>(new RoomSettings(it.key())));
 
                         for (const auto membership : room_state.memberships) {
-                            auto uid = membership.sender();
-                            auto url = membership.content().avatarUrl();
+                                auto uid = membership.sender();
+                                auto url = membership.content().avatarUrl();
 
-                            if (!url.toString().isEmpty())
-                                AvatarProvider::setAvatarUrl(uid, url);
+                                if (!url.toString().isEmpty())
+                                        AvatarProvider::setAvatarUrl(uid, url);
                         }
 
                         view_manager_->addRoom(it.value(), it.key());
-
                 }
 
                 if (it.key() == current_room_)
@@ -358,9 +354,9 @@ ChatPage::syncCompleted(const SyncResponse &response)
         auto leave = response.rooms().leave();
 
         for (auto it = leave.constBegin(); it != leave.constEnd(); it++) {
-            if (state_manager_.contains(it.key())) {
-                leftRoom(it.key());
-            }
+                if (state_manager_.contains(it.key())) {
+                        leftRoom(it.key());
+                }
         }
 
         try {
@@ -589,34 +585,33 @@ ChatPage::showQuickSwitcher()
 void
 ChatPage::joinedRoom(const QString &room_id)
 {
-    if (!state_manager_.contains(room_id)) {
-        RoomState room_state;
+        if (!state_manager_.contains(room_id)) {
+                RoomState room_state;
 
-        state_manager_.insert(room_id, room_state);
-        settingsManager_.insert(room_id,
-                                QSharedPointer<RoomSettings>(new RoomSettings(room_id)));
+                state_manager_.insert(room_id, room_state);
+                settingsManager_.insert(room_id,
+                                        QSharedPointer<RoomSettings>(new RoomSettings(room_id)));
 
-        room_list_->addRoom(settingsManager_[room_id], state_manager_[room_id], room_id);
+                room_list_->addRoom(settingsManager_[room_id], state_manager_[room_id], room_id);
 
-        this->changeTopRoomInfo(room_id);
-        room_list_->highlightSelectedRoom(room_id);
-    }
-
+                this->changeTopRoomInfo(room_id);
+                room_list_->highlightSelectedRoom(room_id);
+        }
 }
 
 void
 ChatPage::leftRoom(const QString &room_id)
 {
-    state_manager_.remove(room_id);
-    settingsManager_.remove(room_id);
-    try {
-        cache_->removeRoom(room_id);
-    } catch (const lmdb::error &e) {
-        qCritical() << "The cache couldn't be updated: " << e.what();
-        // TODO: Notify the user.
-        cache_->unmount();
-    }
-    room_list_->removeRoom(room_id, room_id == current_room_);
+        state_manager_.remove(room_id);
+        settingsManager_.remove(room_id);
+        try {
+                cache_->removeRoom(room_id);
+        } catch (const lmdb::error &e) {
+                qCritical() << "The cache couldn't be updated: " << e.what();
+                // TODO: Notify the user.
+                cache_->unmount();
+        }
+        room_list_->removeRoom(room_id, room_id == current_room_);
 }
 
 ChatPage::~ChatPage()

--- a/src/ChatPage.cc
+++ b/src/ChatPage.cc
@@ -193,10 +193,12 @@ ChatPage::ChatPage(QSharedPointer<MatrixClient> client, QWidget *parent)
                 SIGNAL(ownAvatarRetrieved(const QPixmap &)),
                 this,
                 SLOT(setOwnAvatar(const QPixmap &)));
-        connect(
-          client_.data(), SIGNAL(addRoom(const QString &)), this, SLOT(addRoom(const QString &)));
         connect(client_.data(),
-                SIGNAL(removeRoom(const QString &)),
+                SIGNAL(joinedRoom(const QString &)),
+                this,
+                SLOT(addRoom(const QString &)));
+        connect(client_.data(),
+                SIGNAL(leftRoom(const QString &)),
                 this,
                 SLOT(removeRoom(const QString &)));
 

--- a/src/ChatPage.cc
+++ b/src/ChatPage.cc
@@ -193,12 +193,12 @@ ChatPage::ChatPage(QSharedPointer<MatrixClient> client, QWidget *parent)
                 SIGNAL(ownAvatarRetrieved(const QPixmap &)),
                 this,
                 SLOT(setOwnAvatar(const QPixmap &)));
-        connect(client_.data(),
-                SIGNAL(joinedRoom(const QString &)),
-                this,
-                SLOT(joinedRoom(const QString &)));
         connect(
-          client_.data(), SIGNAL(leftRoom(const QString &)), this, SLOT(leftRoom(const QString &)));
+          client_.data(), SIGNAL(addRoom(const QString &)), this, SLOT(addRoom(const QString &)));
+        connect(client_.data(),
+                SIGNAL(removeRoom(const QString &)),
+                this,
+                SLOT(removeRoom(const QString &)));
 
         AvatarProvider::init(client);
 }
@@ -355,7 +355,7 @@ ChatPage::syncCompleted(const SyncResponse &response)
 
         for (auto it = leave.constBegin(); it != leave.constEnd(); it++) {
                 if (state_manager_.contains(it.key())) {
-                        leftRoom(it.key());
+                        removeRoom(it.key());
                 }
         }
 
@@ -583,7 +583,7 @@ ChatPage::showQuickSwitcher()
 }
 
 void
-ChatPage::joinedRoom(const QString &room_id)
+ChatPage::addRoom(const QString &room_id)
 {
         if (!state_manager_.contains(room_id)) {
                 RoomState room_state;
@@ -600,7 +600,7 @@ ChatPage::joinedRoom(const QString &room_id)
 }
 
 void
-ChatPage::leftRoom(const QString &room_id)
+ChatPage::removeRoom(const QString &room_id)
 {
         state_manager_.remove(room_id);
         settingsManager_.remove(room_id);

--- a/src/ChatPage.cc
+++ b/src/ChatPage.cc
@@ -567,6 +567,8 @@ ChatPage::joinedRoom(const QString &room_id)
     settingsManager_.insert(room_id,
                             QSharedPointer<RoomSettings>(new RoomSettings(room_id)));
 
+    room_list_->addRoom(settingsManager_[room_id], state_manager_[room_id], room_id);
+
     this->changeTopRoomInfo(room_id);
 }
 

--- a/src/EmojiPanel.cc
+++ b/src/EmojiPanel.cc
@@ -34,12 +34,13 @@ EmojiPanel::EmojiPanel(QWidget *parent)
   , animationDuration_{ 100 }
   , categoryIconSize_{ 20 }
 {
-        setStyleSheet(
-          "QWidget {background: #fff; color: #e8e8e8; border: none;}"
-          "QScrollBar:vertical { background-color: #fff; width: 8px; margin: 0px 2px 0 2px; }"
-          "QScrollBar::handle:vertical { background-color: #d6dde3; min-height: 20px; }"
-          "QScrollBar::add-line:vertical { border: none; background: none; }"
-          "QScrollBar::sub-line:vertical { border: none; background: none; }");
+        setStyleSheet("QWidget {background: #fff; color: #e8e8e8; border: none;}"
+                      "QScrollBar:vertical { background-color: #fff; width: 8px; margin: 0px "
+                      "2px 0 2px; }"
+                      "QScrollBar::handle:vertical { background-color: #d6dde3; min-height: "
+                      "20px; }"
+                      "QScrollBar::add-line:vertical { border: none; background: none; }"
+                      "QScrollBar::sub-line:vertical { border: none; background: none; }");
 
         setAttribute(Qt::WA_TranslucentBackground, true);
         setAttribute(Qt::WA_ShowWithoutActivating, true);

--- a/src/InputValidator.cc
+++ b/src/InputValidator.cc
@@ -20,8 +20,8 @@
 const QRegExp MXID_REGEX("@[A-Za-z0-9._%+-]+:[A-Za-z0-9.-]{1,126}\\.[A-Za-z]{1,63}");
 const QRegExp LOCALPART_REGEX("[A-za-z0-9._%+-]{3,}");
 const QRegExp PASSWORD_REGEX(".{8,}");
-const QRegExp DOMAIN_REGEX(
-  "(?!\\-)(?:[a-zA-Z\\d\\-]{0,62}[a-zA-Z\\d]\\.){1,126}(?!\\d+)[a-zA-Z\\d]{1,63}");
+const QRegExp DOMAIN_REGEX("(?!\\-)(?:[a-zA-Z\\d\\-]{0,62}[a-zA-Z\\d]\\.){1,"
+                           "126}(?!\\d+)[a-zA-Z\\d]{1,63}");
 
 QRegExpValidator InputValidator::Id(MXID_REGEX);
 QRegExpValidator InputValidator::Localpart(LOCALPART_REGEX);

--- a/src/JoinRoomDialog.cc
+++ b/src/JoinRoomDialog.cc
@@ -1,0 +1,47 @@
+#include <QLabel>
+#include <QVBoxLayout>
+
+#include "Config.h"
+#include "JoinRoomDialog.h"
+#include "Theme.h"
+
+JoinRoomDialog::JoinRoomDialog(QWidget *parent)
+  : QFrame(parent)
+{
+        setMaximumSize(400, 400);
+        setStyleSheet("background-color: #fff");
+
+        auto layout = new QVBoxLayout(this);
+        layout->setSpacing(30);
+        layout->setMargin(20);
+
+        auto buttonLayout = new QHBoxLayout();
+        buttonLayout->setSpacing(0);
+        buttonLayout->setMargin(0);
+
+        confirmBtn_ = new FlatButton("JOIN", this);
+        confirmBtn_->setFontSize(conf::btn::fontSize);
+
+        cancelBtn_ = new FlatButton(tr("CANCEL"), this);
+        cancelBtn_->setFontSize(conf::btn::fontSize);
+
+        buttonLayout->addStretch(1);
+        buttonLayout->addWidget(confirmBtn_);
+        buttonLayout->addWidget(cancelBtn_);
+
+        QFont font;
+        font.setPixelSize(conf::headerFontSize);
+
+        auto label = new QLabel(tr("Room alias to join:"), this);
+        label->setFont(font);
+        label->setStyleSheet("color: #333333");
+
+        roomAliasEdit_ = new QLineEdit(this);
+
+        layout->addWidget(label);
+        layout->addWidget(roomAliasEdit_);
+        layout->addLayout(buttonLayout);
+
+        connect(confirmBtn_, &QPushButton::clicked, [=]() { emit closing(true, roomAliasEdit_->text()); });
+        connect(cancelBtn_, &QPushButton::clicked, [=]() { emit closing(false, nullptr); });
+}

--- a/src/JoinRoomDialog.cc
+++ b/src/JoinRoomDialog.cc
@@ -42,6 +42,8 @@ JoinRoomDialog::JoinRoomDialog(QWidget *parent)
         layout->addWidget(roomAliasEdit_);
         layout->addLayout(buttonLayout);
 
-        connect(confirmBtn_, &QPushButton::clicked, [=]() { emit closing(true, roomAliasEdit_->text()); });
+        connect(confirmBtn_, &QPushButton::clicked, [=]() {
+                emit closing(true, roomAliasEdit_->text());
+        });
         connect(cancelBtn_, &QPushButton::clicked, [=]() { emit closing(false, nullptr); });
 }

--- a/src/LeaveRoomDialog.cc
+++ b/src/LeaveRoomDialog.cc
@@ -1,0 +1,44 @@
+#include <QLabel>
+#include <QVBoxLayout>
+
+#include "Config.h"
+#include "LeaveRoomDialog.h"
+#include "Theme.h"
+
+LeaveRoomDialog::LeaveRoomDialog(QWidget *parent)
+  : QFrame(parent)
+{
+        setMaximumSize(400, 400);
+        setStyleSheet("background-color: #fff");
+
+        auto layout = new QVBoxLayout(this);
+        layout->setSpacing(30);
+        layout->setMargin(20);
+
+        auto buttonLayout = new QHBoxLayout();
+        buttonLayout->setSpacing(0);
+        buttonLayout->setMargin(0);
+
+        confirmBtn_ = new FlatButton("LEAVE", this);
+        confirmBtn_->setFontSize(conf::btn::fontSize);
+
+        cancelBtn_ = new FlatButton(tr("CANCEL"), this);
+        cancelBtn_->setFontSize(conf::btn::fontSize);
+
+        buttonLayout->addStretch(1);
+        buttonLayout->addWidget(confirmBtn_);
+        buttonLayout->addWidget(cancelBtn_);
+
+        QFont font;
+        font.setPixelSize(conf::headerFontSize);
+
+        auto label = new QLabel(tr("Are you sure you want to leave?"), this);
+        label->setFont(font);
+        label->setStyleSheet("color: #333333");
+
+        layout->addWidget(label);
+        layout->addLayout(buttonLayout);
+
+        connect(confirmBtn_, &QPushButton::clicked, [=]() { emit closing(true); });
+        connect(cancelBtn_, &QPushButton::clicked, [=]() { emit closing(false); });
+}

--- a/src/MatrixClient.cc
+++ b/src/MatrixClient.cc
@@ -871,13 +871,6 @@ MatrixClient::uploadImage(const QString &roomid, const QString &filename)
 
         QFile file(filename);
         if (!file.open(QIODevice::ReadWrite)) {
-                QUrl endpoint(server_);
-                endpoint.setPath("/_matrix/client/versions");
-
-                QNetworkRequest request(endpoint);
-
-                QNetworkReply *reply = get(request);
-                reply->setProperty("endpoint", static_cast<int>(Endpoint::Versions));
                 qDebug() << "Error while reading" << filename;
                 return;
         }

--- a/src/MatrixClient.cc
+++ b/src/MatrixClient.cc
@@ -474,9 +474,9 @@ MatrixClient::onJoinRoomResponse(QNetworkReply *reply)
                 return;
         }
 
-        auto data    = reply->readAll();
+        auto data              = reply->readAll();
         QJsonDocument response = QJsonDocument::fromJson(data);
-        QString room_id = response.object()["room_id"].toString();
+        QString room_id        = response.object()["room_id"].toString();
         emit joinedRoom(room_id);
 }
 
@@ -611,11 +611,8 @@ void
 MatrixClient::sync() noexcept
 {
         QJsonObject filter{ { "room",
-                              QJsonObject{
-                                  { "include_leave", true },
-                                  { "ephemeral", QJsonObject{ { "limit", 0 } } }
-                              }
-                            },
+                              QJsonObject{ { "include_leave", true },
+                                           { "ephemeral", QJsonObject{ { "limit", 0 } } } } },
                             { "presence", QJsonObject{ { "limit", 0 } } } };
 
         QUrlQuery query;
@@ -898,7 +895,7 @@ MatrixClient::joinRoom(const QString &roomIdOrAlias)
         endpoint.setQuery(query);
 
         QNetworkRequest request(endpoint);
-        request.setHeader(QNetworkRequest::KnownHeaders::ContentTypeHeader,"application/json");
+        request.setHeader(QNetworkRequest::KnownHeaders::ContentTypeHeader, "application/json");
 
         QNetworkReply *reply = post(request, "{}");
         reply->setProperty("endpoint", static_cast<int>(Endpoint::JoinRoom));
@@ -915,7 +912,7 @@ MatrixClient::leaveRoom(const QString &roomId)
         endpoint.setQuery(query);
 
         QNetworkRequest request(endpoint);
-        request.setHeader(QNetworkRequest::KnownHeaders::ContentTypeHeader,"application/json");
+        request.setHeader(QNetworkRequest::KnownHeaders::ContentTypeHeader, "application/json");
 
         QNetworkReply *reply = post(request, "{}");
         reply->setProperty("room_id", roomId);

--- a/src/RoomInfoListItem.cc
+++ b/src/RoomInfoListItem.cc
@@ -53,12 +53,17 @@ RoomInfoListItem::RoomInfoListItem(QSharedPointer<RoomSettings> settings,
         menu_ = new Menu(this);
 
         toggleNotifications_ = new QAction(notificationText(), this);
-
         connect(toggleNotifications_, &QAction::triggered, this, [=]() {
                 roomSettings_->toggleNotifications();
         });
 
+        leaveRoom_ = new QAction(tr("Leave room"), this);
+        connect(leaveRoom_, &QAction::triggered, this, [=](){
+                emit leaveRoom(room_id);
+        });
+
         menu_->addAction(toggleNotifications_);
+        menu_->addAction(leaveRoom_);
 }
 
 QString

--- a/src/RoomInfoListItem.cc
+++ b/src/RoomInfoListItem.cc
@@ -58,9 +58,7 @@ RoomInfoListItem::RoomInfoListItem(QSharedPointer<RoomSettings> settings,
         });
 
         leaveRoom_ = new QAction(tr("Leave room"), this);
-        connect(leaveRoom_, &QAction::triggered, this, [=](){
-                emit leaveRoom(room_id);
-        });
+        connect(leaveRoom_, &QAction::triggered, this, [=]() { emit leaveRoom(room_id); });
 
         menu_->addAction(toggleNotifications_);
         menu_->addAction(leaveRoom_);

--- a/src/RoomList.cc
+++ b/src/RoomList.cc
@@ -77,18 +77,7 @@ RoomList::addRoom(const QSharedPointer<RoomSettings> &settings,
 {
         RoomInfoListItem *room_item = new RoomInfoListItem(settings, state, room_id, scrollArea_);
         connect(room_item, &RoomInfoListItem::clicked, this, &RoomList::highlightSelectedRoom);
-        connect(room_item, &RoomInfoListItem::leaveRoom, client_.data(), [=]() {
-                leaveRoomDialog_ = new LeaveRoomDialog(this);
-                connect(leaveRoomDialog_, &LeaveRoomDialog::closing, this, [=](bool leaving) {
-                        closeLeaveRoomDialog(leaving, room_id);
-                });
-
-                leaveRoomModal = new OverlayModal(MainWindow::instance(), leaveRoomDialog_);
-                leaveRoomModal->setDuration(100);
-                leaveRoomModal->setColor(QColor(55, 55, 55, 170));
-
-                leaveRoomModal->fadeIn();
-        });
+        connect(room_item, &RoomInfoListItem::leaveRoom, this, &RoomList::openLeaveRoomDialog);
 
         rooms_.insert(room_id, QSharedPointer<RoomInfoListItem>(room_item));
 
@@ -158,19 +147,7 @@ RoomList::setInitialRooms(const QMap<QString, QSharedPointer<RoomSettings>> &set
                   new RoomInfoListItem(settings[room_id], state, room_id, scrollArea_);
                 connect(
                   room_item, &RoomInfoListItem::clicked, this, &RoomList::highlightSelectedRoom);
-                connect(room_item, &RoomInfoListItem::leaveRoom, client_.data(), [=]() {
-                        leaveRoomDialog_ = new LeaveRoomDialog(this);
-                        connect(leaveRoomDialog_,
-                                &LeaveRoomDialog::closing,
-                                this,
-                                [=](bool leaving) { closeLeaveRoomDialog(leaving, room_id); });
-
-                        leaveRoomModal = new OverlayModal(MainWindow::instance(), leaveRoomDialog_);
-                        leaveRoomModal->setDuration(100);
-                        leaveRoomModal->setColor(QColor(55, 55, 55, 170));
-
-                        leaveRoomModal->fadeIn();
-                });
+                connect(room_item, &RoomInfoListItem::leaveRoom, this, &RoomList::openLeaveRoomDialog);
 
                 rooms_.insert(room_id, QSharedPointer<RoomInfoListItem>(room_item));
 
@@ -185,6 +162,21 @@ RoomList::setInitialRooms(const QMap<QString, QSharedPointer<RoomSettings>> &set
         first_room->setPressedState(true);
 
         emit roomChanged(rooms_.firstKey());
+}
+
+void
+RoomList::openLeaveRoomDialog(const QString &room_id)
+{
+        leaveRoomDialog_ = new LeaveRoomDialog(this);
+        connect(leaveRoomDialog_,
+                &LeaveRoomDialog::closing, this,
+                [=](bool leaving) { closeLeaveRoomDialog(leaving, room_id); });
+
+        leaveRoomModal = new OverlayModal(MainWindow::instance(), leaveRoomDialog_);
+        leaveRoomModal->setDuration(100);
+        leaveRoomModal->setColor(QColor(55, 55, 55, 170));
+
+        leaveRoomModal->fadeIn();
 }
 
 void

--- a/src/RoomList.cc
+++ b/src/RoomList.cc
@@ -103,9 +103,7 @@ RoomList::addRoom(const QSharedPointer<RoomSettings> &settings,
 
         rooms_.insert(room_id, QSharedPointer<RoomInfoListItem>(room_item));
 
-        int pos = contentsLayout_->count() - 1;
-        contentsLayout_->insertWidget(pos, room_item);
-}
+        contentsLayout_->insertWidget(0, room_item);}
 
 void
 RoomList::removeRoom(const QString &room_id, bool reset)
@@ -196,8 +194,9 @@ RoomList::sync(const QMap<QString, RoomState> &states)
                 auto state   = it.value();
 
                 // TODO: Add the new room to the list.
-                if (!rooms_.contains(room_id))
-                        continue;
+                if (!rooms_.contains(room_id)) {
+                        addRoom(QSharedPointer<RoomSettings>(new RoomSettings(room_id)), state, room_id);
+                }
 
                 auto room = rooms_[room_id];
 

--- a/src/RoomList.cc
+++ b/src/RoomList.cc
@@ -56,15 +56,16 @@ RoomList::RoomList(QSharedPointer<MatrixClient> client, QWidget *parent)
         scrollArea_->setWidget(scrollAreaContents_);
         topLayout_->addWidget(scrollArea_);
 
-        joinRoomButton_ = new QPushButton("Join room", this);
-        topLayout_->addWidget(joinRoomButton_);
+        //joinRoomButton_ = new QPushButton("Join room", this);
+        //topLayout_->addWidget(joinRoomButton_);
 
         connect(client_.data(),
                 SIGNAL(roomAvatarRetrieved(const QString &, const QPixmap &)),
                 this,
                 SLOT(updateRoomAvatar(const QString &, const QPixmap &)));
 
-        connect(joinRoomButton_, &QPushButton::clicked, this, [=]() {
+        /* Nonfunctional and disabled
+         * connect(joinRoomButton_, &QPushButton::clicked, this, [=]() {
                 joinRoomDialog_ = new JoinRoomDialog(this);
                 connect(joinRoomDialog_,
                     SIGNAL(closing(bool, QString)),
@@ -77,6 +78,7 @@ RoomList::RoomList(QSharedPointer<MatrixClient> client, QWidget *parent)
 
                 joinRoomModal_->fadeIn();
         });
+        */
 }
 
 RoomList::~RoomList() {}

--- a/src/RoomList.cc
+++ b/src/RoomList.cc
@@ -173,7 +173,7 @@ RoomList::openLeaveRoomDialog(const QString &room_id)
                 [=](bool leaving) { closeLeaveRoomDialog(leaving, room_id); });
 
         leaveRoomModal = new OverlayModal(MainWindow::instance(), leaveRoomDialog_);
-        leaveRoomModal->setDuration(100);
+        leaveRoomModal->setDuration(0);
         leaveRoomModal->setColor(QColor(55, 55, 55, 170));
 
         leaveRoomModal->fadeIn();

--- a/src/RoomList.cc
+++ b/src/RoomList.cc
@@ -19,10 +19,10 @@
 #include <QJsonArray>
 #include <QRegularExpression>
 
+#include "MainWindow.h"
 #include "RoomInfoListItem.h"
 #include "RoomList.h"
 #include "Sync.h"
-#include "MainWindow.h"
 
 RoomList::RoomList(QSharedPointer<MatrixClient> client, QWidget *parent)
   : QWidget(parent)
@@ -56,8 +56,8 @@ RoomList::RoomList(QSharedPointer<MatrixClient> client, QWidget *parent)
         scrollArea_->setWidget(scrollAreaContents_);
         topLayout_->addWidget(scrollArea_);
 
-        //joinRoomButton_ = new QPushButton("Join room", this);
-        //topLayout_->addWidget(joinRoomButton_);
+        // joinRoomButton_ = new QPushButton("Join room", this);
+        // topLayout_->addWidget(joinRoomButton_);
 
         connect(client_.data(),
                 SIGNAL(roomAvatarRetrieved(const QString &, const QPixmap &)),
@@ -94,18 +94,14 @@ RoomList::addRoom(const QSharedPointer<RoomSettings> &settings,
                   const RoomState &state,
                   const QString &room_id)
 {
-        RoomInfoListItem *room_item =
-          new RoomInfoListItem(settings, state, room_id, scrollArea_);
-        connect(
-            room_item, &RoomInfoListItem::clicked,
-            this, &RoomList::highlightSelectedRoom);
-        connect(
-            room_item, &RoomInfoListItem::leaveRoom,
-            client_.data(), &MatrixClient::leaveRoom);
+        RoomInfoListItem *room_item = new RoomInfoListItem(settings, state, room_id, scrollArea_);
+        connect(room_item, &RoomInfoListItem::clicked, this, &RoomList::highlightSelectedRoom);
+        connect(room_item, &RoomInfoListItem::leaveRoom, client_.data(), &MatrixClient::leaveRoom);
 
         rooms_.insert(room_id, QSharedPointer<RoomInfoListItem>(room_item));
 
-        contentsLayout_->insertWidget(0, room_item);}
+        contentsLayout_->insertWidget(0, room_item);
+}
 
 void
 RoomList::removeRoom(const QString &room_id, bool reset)
@@ -167,11 +163,11 @@ RoomList::setInitialRooms(const QMap<QString, QSharedPointer<RoomSettings>> &set
                 RoomInfoListItem *room_item =
                   new RoomInfoListItem(settings[room_id], state, room_id, scrollArea_);
                 connect(
-                            room_item, &RoomInfoListItem::clicked,
-                            this, &RoomList::highlightSelectedRoom);
-                connect(
-                            room_item, &RoomInfoListItem::leaveRoom,
-                            client_.data(), &MatrixClient::leaveRoom);
+                  room_item, &RoomInfoListItem::clicked, this, &RoomList::highlightSelectedRoom);
+                connect(room_item,
+                        &RoomInfoListItem::leaveRoom,
+                        client_.data(),
+                        &MatrixClient::leaveRoom);
 
                 rooms_.insert(room_id, QSharedPointer<RoomInfoListItem>(room_item));
 
@@ -197,7 +193,8 @@ RoomList::sync(const QMap<QString, RoomState> &states)
 
                 // TODO: Add the new room to the list.
                 if (!rooms_.contains(room_id)) {
-                        addRoom(QSharedPointer<RoomSettings>(new RoomSettings(room_id)), state, room_id);
+                        addRoom(
+                          QSharedPointer<RoomSettings>(new RoomSettings(room_id)), state, room_id);
                 }
 
                 auto room = rooms_[room_id];
@@ -267,6 +264,6 @@ RoomList::closeJoinRoomDialog(bool isJoining, QString roomAlias)
         joinRoomModal_->fadeOut();
 
         if (isJoining) {
-           client_->joinRoom(roomAlias);
+                client_->joinRoom(roomAlias);
         }
 }

--- a/src/RoomList.cc
+++ b/src/RoomList.cc
@@ -92,6 +92,20 @@ RoomList::clear()
 }
 
 void
+RoomList::removeRoom(const QString &room_id, bool reset)
+{
+        rooms_.remove(room_id);
+
+        if (rooms_.isEmpty() || !reset)
+                return;
+
+        auto first_room = rooms_.first();
+        first_room->setPressedState(true);
+
+        emit roomChanged(rooms_.firstKey());
+}
+
+void
 RoomList::updateUnreadMessageCount(const QString &roomid, int count)
 {
         if (!rooms_.contains(roomid)) {
@@ -137,7 +151,11 @@ RoomList::setInitialRooms(const QMap<QString, QSharedPointer<RoomSettings>> &set
                 RoomInfoListItem *room_item =
                   new RoomInfoListItem(settings[room_id], state, room_id, scrollArea_);
                 connect(
-                  room_item, &RoomInfoListItem::clicked, this, &RoomList::highlightSelectedRoom);
+                            room_item, &RoomInfoListItem::clicked,
+                            this, &RoomList::highlightSelectedRoom);
+                connect(
+                            room_item, &RoomInfoListItem::leaveRoom,
+                            client_.data(), &MatrixClient::leaveRoom);
 
                 rooms_.insert(room_id, QSharedPointer<RoomInfoListItem>(room_item));
 

--- a/src/Sync.cc
+++ b/src/Sync.cc
@@ -82,7 +82,6 @@ Rooms::deserialize(const QJsonValue &data)
 
         QJsonObject object = data.toObject();
 
-<<<<<<< HEAD
         if (object.contains("join")) {
                 if (!object.value("join").isObject())
                         throw DeserializationException("rooms/join must be a JSON object");
@@ -97,40 +96,7 @@ Rooms::deserialize(const QJsonValue &data)
                         } catch (DeserializationException &e) {
                                 qWarning() << e.what();
                                 qWarning() << "Skipping malformed object for room" << it.key();
-                        }
-=======
-        if (!object.contains("join"))
-                throw DeserializationException("rooms/join is missing");
-
-        if (!object.contains("invite"))
-                throw DeserializationException("rooms/invite is missing");
-
-        if (!object.contains("leave"))
-                throw DeserializationException("rooms/leave is missing");
-
-        if (!object.value("join").isObject())
-                throw DeserializationException("rooms/join must be a JSON object");
-
-        if (!object.value("invite").isObject())
-                throw DeserializationException("rooms/invite must be a JSON object");
-
-        if (!object.value("leave").isObject())
-                throw DeserializationException("rooms/leave must be a JSON object");
-
-        auto join  = object.value("join").toObject();
-        auto leave = object.value("leave").toObject();
-
-        for (auto it = join.constBegin(); it != join.constEnd(); it++) {
-                JoinedRoom tmp_room;
-
-                try {
-                        tmp_room.deserialize(it.value());
-                        join_.insert(it.key(), tmp_room);
-                } catch (DeserializationException &e) {
-                        qWarning() << e.what();
-                        qWarning() << "Skipping malformed object for room" << it.key();
->>>>>>> `make lint`
-                }
+                        }                }
         }
 
         if (object.contains("invite")) {
@@ -238,18 +204,18 @@ LeftRoom::deserialize(const QJsonValue &data)
         QJsonObject object = data.toObject();
 
         if (!object.contains("state"))
-                throw DeserializationException("join/state is missing");
+                throw DeserializationException("leave/state is missing");
 
         if (!object.contains("timeline"))
-                throw DeserializationException("join/timeline is missing");
+                throw DeserializationException("leave/timeline is missing");
 
         if (!object.value("state").isObject())
-                throw DeserializationException("join/state should be an object");
+                throw DeserializationException("leave/state should be an object");
 
         QJsonObject state = object.value("state").toObject();
 
         if (!state.contains("events"))
-                throw DeserializationException("join/state/events is missing");
+                throw DeserializationException("leave/state/events is missing");
 
         state_.deserialize(state.value("events"));
         timeline_.deserialize(object.value("timeline"));

--- a/src/Sync.cc
+++ b/src/Sync.cc
@@ -82,6 +82,7 @@ Rooms::deserialize(const QJsonValue &data)
 
         QJsonObject object = data.toObject();
 
+<<<<<<< HEAD
         if (object.contains("join")) {
                 if (!object.value("join").isObject())
                         throw DeserializationException("rooms/join must be a JSON object");
@@ -97,6 +98,38 @@ Rooms::deserialize(const QJsonValue &data)
                                 qWarning() << e.what();
                                 qWarning() << "Skipping malformed object for room" << it.key();
                         }
+=======
+        if (!object.contains("join"))
+                throw DeserializationException("rooms/join is missing");
+
+        if (!object.contains("invite"))
+                throw DeserializationException("rooms/invite is missing");
+
+        if (!object.contains("leave"))
+                throw DeserializationException("rooms/leave is missing");
+
+        if (!object.value("join").isObject())
+                throw DeserializationException("rooms/join must be a JSON object");
+
+        if (!object.value("invite").isObject())
+                throw DeserializationException("rooms/invite must be a JSON object");
+
+        if (!object.value("leave").isObject())
+                throw DeserializationException("rooms/leave must be a JSON object");
+
+        auto join  = object.value("join").toObject();
+        auto leave = object.value("leave").toObject();
+
+        for (auto it = join.constBegin(); it != join.constEnd(); it++) {
+                JoinedRoom tmp_room;
+
+                try {
+                        tmp_room.deserialize(it.value());
+                        join_.insert(it.key(), tmp_room);
+                } catch (DeserializationException &e) {
+                        qWarning() << e.what();
+                        qWarning() << "Skipping malformed object for room" << it.key();
+>>>>>>> `make lint`
                 }
         }
 

--- a/src/Sync.cc
+++ b/src/Sync.cc
@@ -96,7 +96,8 @@ Rooms::deserialize(const QJsonValue &data)
                         } catch (DeserializationException &e) {
                                 qWarning() << e.what();
                                 qWarning() << "Skipping malformed object for room" << it.key();
-                        }                }
+                        }
+                }
         }
 
         if (object.contains("invite")) {
@@ -124,7 +125,6 @@ Rooms::deserialize(const QJsonValue &data)
                         }
                 }
         }
-
 }
 
 void

--- a/src/TimelineViewManager.cc
+++ b/src/TimelineViewManager.cc
@@ -101,19 +101,7 @@ void
 TimelineViewManager::initialize(const Rooms &rooms)
 {
         for (auto it = rooms.join().constBegin(); it != rooms.join().constEnd(); it++) {
-                auto roomid = it.key();
-
-                // Create a history view with the room events.
-                TimelineView *view = new TimelineView(it.value().timeline(), client_, it.key());
-                views_.insert(it.key(), QSharedPointer<TimelineView>(view));
-
-                connect(view,
-                        &TimelineView::updateLastTimelineMessage,
-                        this,
-                        &TimelineViewManager::updateRoomsLastMessage);
-
-                // Add the view in the widget stack.
-                addWidget(view);
+                addRoom(it.value(), it.key());
         }
 }
 
@@ -121,18 +109,40 @@ void
 TimelineViewManager::initialize(const QList<QString> &rooms)
 {
         for (const auto &roomid : rooms) {
-                // Create a history view without any events.
-                TimelineView *view = new TimelineView(client_, roomid);
-                views_.insert(roomid, QSharedPointer<TimelineView>(view));
-
-                connect(view,
-                        &TimelineView::updateLastTimelineMessage,
-                        this,
-                        &TimelineViewManager::updateRoomsLastMessage);
-
-                // Add the view in the widget stack.
-                addWidget(view);
+                addRoom(roomid);
         }
+}
+
+void
+TimelineViewManager::addRoom(const JoinedRoom &room, const QString &room_id)
+{
+        // Create a history view with the room events.
+        TimelineView *view = new TimelineView(room.timeline(), client_, room_id);
+        views_.insert(room_id, QSharedPointer<TimelineView>(view));
+
+        connect(view,
+            &TimelineView::updateLastTimelineMessage,
+            this,
+            &TimelineViewManager::updateRoomsLastMessage);
+
+        // Add the view in the widget stack.
+        addWidget(view);
+}
+
+void
+TimelineViewManager::addRoom(const QString &room_id)
+{
+        // Create a history view without any events.
+        TimelineView *view = new TimelineView(client_, room_id);
+        views_.insert(room_id, QSharedPointer<TimelineView>(view));
+
+        connect(view,
+            &TimelineView::updateLastTimelineMessage,
+            this,
+            &TimelineViewManager::updateRoomsLastMessage);
+
+        // Add the view in the widget stack.
+        addWidget(view);
 }
 
 void

--- a/src/TimelineViewManager.cc
+++ b/src/TimelineViewManager.cc
@@ -121,9 +121,9 @@ TimelineViewManager::addRoom(const JoinedRoom &room, const QString &room_id)
         views_.insert(room_id, QSharedPointer<TimelineView>(view));
 
         connect(view,
-            &TimelineView::updateLastTimelineMessage,
-            this,
-            &TimelineViewManager::updateRoomsLastMessage);
+                &TimelineView::updateLastTimelineMessage,
+                this,
+                &TimelineViewManager::updateRoomsLastMessage);
 
         // Add the view in the widget stack.
         addWidget(view);
@@ -137,9 +137,9 @@ TimelineViewManager::addRoom(const QString &room_id)
         views_.insert(room_id, QSharedPointer<TimelineView>(view));
 
         connect(view,
-            &TimelineView::updateLastTimelineMessage,
-            this,
-            &TimelineViewManager::updateRoomsLastMessage);
+                &TimelineView::updateLastTimelineMessage,
+                this,
+                &TimelineViewManager::updateRoomsLastMessage);
 
         // Add the view in the widget stack.
         addWidget(view);

--- a/src/TopRoomBar.cc
+++ b/src/TopRoomBar.cc
@@ -83,7 +83,13 @@ TopRoomBar::TopRoomBar(QWidget *parent)
                 roomSettings_->toggleNotifications();
         });
 
+        leaveRoom_ = new QAction(tr("Leave room"), this);
+        connect(leaveRoom_, &QAction::triggered, this, [=](){
+            emit leaveRoom();
+        });
+
         menu_->addAction(toggleNotifications_);
+        menu_->addAction(leaveRoom_);
 
         connect(settingsBtn_, &QPushButton::clicked, this, [=]() {
                 if (roomSettings_->isNotificationsEnabled())

--- a/src/TopRoomBar.cc
+++ b/src/TopRoomBar.cc
@@ -84,9 +84,7 @@ TopRoomBar::TopRoomBar(QWidget *parent)
         });
 
         leaveRoom_ = new QAction(tr("Leave room"), this);
-        connect(leaveRoom_, &QAction::triggered, this, [=](){
-            emit leaveRoom();
-        });
+        connect(leaveRoom_, &QAction::triggered, this, [=]() { emit leaveRoom(); });
 
         menu_->addAction(toggleNotifications_);
         menu_->addAction(leaveRoom_);

--- a/src/TopRoomBar.cc
+++ b/src/TopRoomBar.cc
@@ -18,6 +18,7 @@
 #include <QStyleOption>
 
 #include "Config.h"
+#include "MainWindow.h"
 #include "TopRoomBar.h"
 
 TopRoomBar::TopRoomBar(QWidget *parent)
@@ -84,7 +85,17 @@ TopRoomBar::TopRoomBar(QWidget *parent)
         });
 
         leaveRoom_ = new QAction(tr("Leave room"), this);
-        connect(leaveRoom_, &QAction::triggered, this, [=]() { emit leaveRoom(); });
+        connect(leaveRoom_, &QAction::triggered, this, [=]() {
+                leaveRoomDialog_ = new LeaveRoomDialog(this);
+                connect(
+                  leaveRoomDialog_, SIGNAL(closing(bool)), this, SLOT(closeLeaveRoomDialog(bool)));
+
+                leaveRoomModal = new OverlayModal(MainWindow::instance(), leaveRoomDialog_);
+                leaveRoomModal->setDuration(100);
+                leaveRoomModal->setColor(QColor(55, 55, 55, 170));
+
+                leaveRoomModal->fadeIn();
+        });
 
         menu_->addAction(toggleNotifications_);
         menu_->addAction(leaveRoom_);
@@ -101,6 +112,16 @@ TopRoomBar::TopRoomBar(QWidget *parent)
         });
 
         setLayout(topLayout_);
+}
+
+void
+TopRoomBar::closeLeaveRoomDialog(bool leaving)
+{
+        leaveRoomModal->fadeOut();
+
+        if (leaving) {
+                emit leaveRoom();
+        }
 }
 
 void

--- a/tests/message_events.cc
+++ b/tests/message_events.cc
@@ -99,7 +99,10 @@ TEST(MessageEvent, File)
 TEST(MessageEvent, Image)
 {
         auto thumbinfo = QJsonObject{
-                { "h", 11 }, { "w", 22 }, { "size", 212 }, { "mimetype", "img/jpeg" },
+                { "h", 11 },
+                { "w", 22 },
+                { "size", 212 },
+                { "mimetype", "img/jpeg" },
         };
 
         auto imginfo = QJsonObject{
@@ -239,49 +242,49 @@ TEST(MessageEvent, Video)
 
 TEST(MessageEvent, Types)
 {
-        EXPECT_EQ(
-          extractMessageEventType(QJsonObject{
-            { "content", QJsonObject{ { "msgtype", "m.audio" } } }, { "type", "m.room.message" },
-          }),
-          MessageEventType::Audio);
-        EXPECT_EQ(
-          extractMessageEventType(QJsonObject{
-            { "content", QJsonObject{ { "msgtype", "m.emote" } } }, { "type", "m.room.message" },
-          }),
-          MessageEventType::Emote);
-        EXPECT_EQ(
-          extractMessageEventType(QJsonObject{
-            { "content", QJsonObject{ { "msgtype", "m.file" } } }, { "type", "m.room.message" },
-          }),
-          MessageEventType::File);
-        EXPECT_EQ(
-          extractMessageEventType(QJsonObject{
-            { "content", QJsonObject{ { "msgtype", "m.image" } } }, { "type", "m.room.message" },
-          }),
-          MessageEventType::Image);
-        EXPECT_EQ(
-          extractMessageEventType(QJsonObject{
-            { "content", QJsonObject{ { "msgtype", "m.location" } } }, { "type", "m.room.message" },
-          }),
-          MessageEventType::Location);
-        EXPECT_EQ(
-          extractMessageEventType(QJsonObject{
-            { "content", QJsonObject{ { "msgtype", "m.notice" } } }, { "type", "m.room.message" },
-          }),
-          MessageEventType::Notice);
-        EXPECT_EQ(
-          extractMessageEventType(QJsonObject{
-            { "content", QJsonObject{ { "msgtype", "m.text" } } }, { "type", "m.room.message" },
-          }),
-          MessageEventType::Text);
-        EXPECT_EQ(
-          extractMessageEventType(QJsonObject{
-            { "content", QJsonObject{ { "msgtype", "m.video" } } }, { "type", "m.room.message" },
-          }),
-          MessageEventType::Video);
-        EXPECT_EQ(
-          extractMessageEventType(QJsonObject{
-            { "content", QJsonObject{ { "msgtype", "m.random" } } }, { "type", "m.room.message" },
-          }),
-          MessageEventType::Unknown);
+        EXPECT_EQ(extractMessageEventType(QJsonObject{
+                    { "content", QJsonObject{ { "msgtype", "m.audio" } } },
+                    { "type", "m.room.message" },
+                  }),
+                  MessageEventType::Audio);
+        EXPECT_EQ(extractMessageEventType(QJsonObject{
+                    { "content", QJsonObject{ { "msgtype", "m.emote" } } },
+                    { "type", "m.room.message" },
+                  }),
+                  MessageEventType::Emote);
+        EXPECT_EQ(extractMessageEventType(QJsonObject{
+                    { "content", QJsonObject{ { "msgtype", "m.file" } } },
+                    { "type", "m.room.message" },
+                  }),
+                  MessageEventType::File);
+        EXPECT_EQ(extractMessageEventType(QJsonObject{
+                    { "content", QJsonObject{ { "msgtype", "m.image" } } },
+                    { "type", "m.room.message" },
+                  }),
+                  MessageEventType::Image);
+        EXPECT_EQ(extractMessageEventType(QJsonObject{
+                    { "content", QJsonObject{ { "msgtype", "m.location" } } },
+                    { "type", "m.room.message" },
+                  }),
+                  MessageEventType::Location);
+        EXPECT_EQ(extractMessageEventType(QJsonObject{
+                    { "content", QJsonObject{ { "msgtype", "m.notice" } } },
+                    { "type", "m.room.message" },
+                  }),
+                  MessageEventType::Notice);
+        EXPECT_EQ(extractMessageEventType(QJsonObject{
+                    { "content", QJsonObject{ { "msgtype", "m.text" } } },
+                    { "type", "m.room.message" },
+                  }),
+                  MessageEventType::Text);
+        EXPECT_EQ(extractMessageEventType(QJsonObject{
+                    { "content", QJsonObject{ { "msgtype", "m.video" } } },
+                    { "type", "m.room.message" },
+                  }),
+                  MessageEventType::Video);
+        EXPECT_EQ(extractMessageEventType(QJsonObject{
+                    { "content", QJsonObject{ { "msgtype", "m.random" } } },
+                    { "type", "m.room.message" },
+                  }),
+                  MessageEventType::Unknown);
 }

--- a/tests/message_events.cc
+++ b/tests/message_events.cc
@@ -99,10 +99,7 @@ TEST(MessageEvent, File)
 TEST(MessageEvent, Image)
 {
         auto thumbinfo = QJsonObject{
-                { "h", 11 },
-                { "w", 22 },
-                { "size", 212 },
-                { "mimetype", "img/jpeg" },
+                { "h", 11 }, { "w", 22 }, { "size", 212 }, { "mimetype", "img/jpeg" },
         };
 
         auto imginfo = QJsonObject{
@@ -242,49 +239,49 @@ TEST(MessageEvent, Video)
 
 TEST(MessageEvent, Types)
 {
-        EXPECT_EQ(extractMessageEventType(QJsonObject{
-                    { "content", QJsonObject{ { "msgtype", "m.audio" } } },
-                    { "type", "m.room.message" },
-                  }),
-                  MessageEventType::Audio);
-        EXPECT_EQ(extractMessageEventType(QJsonObject{
-                    { "content", QJsonObject{ { "msgtype", "m.emote" } } },
-                    { "type", "m.room.message" },
-                  }),
-                  MessageEventType::Emote);
-        EXPECT_EQ(extractMessageEventType(QJsonObject{
-                    { "content", QJsonObject{ { "msgtype", "m.file" } } },
-                    { "type", "m.room.message" },
-                  }),
-                  MessageEventType::File);
-        EXPECT_EQ(extractMessageEventType(QJsonObject{
-                    { "content", QJsonObject{ { "msgtype", "m.image" } } },
-                    { "type", "m.room.message" },
-                  }),
-                  MessageEventType::Image);
-        EXPECT_EQ(extractMessageEventType(QJsonObject{
-                    { "content", QJsonObject{ { "msgtype", "m.location" } } },
-                    { "type", "m.room.message" },
-                  }),
-                  MessageEventType::Location);
-        EXPECT_EQ(extractMessageEventType(QJsonObject{
-                    { "content", QJsonObject{ { "msgtype", "m.notice" } } },
-                    { "type", "m.room.message" },
-                  }),
-                  MessageEventType::Notice);
-        EXPECT_EQ(extractMessageEventType(QJsonObject{
-                    { "content", QJsonObject{ { "msgtype", "m.text" } } },
-                    { "type", "m.room.message" },
-                  }),
-                  MessageEventType::Text);
-        EXPECT_EQ(extractMessageEventType(QJsonObject{
-                    { "content", QJsonObject{ { "msgtype", "m.video" } } },
-                    { "type", "m.room.message" },
-                  }),
-                  MessageEventType::Video);
-        EXPECT_EQ(extractMessageEventType(QJsonObject{
-                    { "content", QJsonObject{ { "msgtype", "m.random" } } },
-                    { "type", "m.room.message" },
-                  }),
-                  MessageEventType::Unknown);
+        EXPECT_EQ(
+          extractMessageEventType(QJsonObject{
+            { "content", QJsonObject{ { "msgtype", "m.audio" } } }, { "type", "m.room.message" },
+          }),
+          MessageEventType::Audio);
+        EXPECT_EQ(
+          extractMessageEventType(QJsonObject{
+            { "content", QJsonObject{ { "msgtype", "m.emote" } } }, { "type", "m.room.message" },
+          }),
+          MessageEventType::Emote);
+        EXPECT_EQ(
+          extractMessageEventType(QJsonObject{
+            { "content", QJsonObject{ { "msgtype", "m.file" } } }, { "type", "m.room.message" },
+          }),
+          MessageEventType::File);
+        EXPECT_EQ(
+          extractMessageEventType(QJsonObject{
+            { "content", QJsonObject{ { "msgtype", "m.image" } } }, { "type", "m.room.message" },
+          }),
+          MessageEventType::Image);
+        EXPECT_EQ(
+          extractMessageEventType(QJsonObject{
+            { "content", QJsonObject{ { "msgtype", "m.location" } } }, { "type", "m.room.message" },
+          }),
+          MessageEventType::Location);
+        EXPECT_EQ(
+          extractMessageEventType(QJsonObject{
+            { "content", QJsonObject{ { "msgtype", "m.notice" } } }, { "type", "m.room.message" },
+          }),
+          MessageEventType::Notice);
+        EXPECT_EQ(
+          extractMessageEventType(QJsonObject{
+            { "content", QJsonObject{ { "msgtype", "m.text" } } }, { "type", "m.room.message" },
+          }),
+          MessageEventType::Text);
+        EXPECT_EQ(
+          extractMessageEventType(QJsonObject{
+            { "content", QJsonObject{ { "msgtype", "m.video" } } }, { "type", "m.room.message" },
+          }),
+          MessageEventType::Video);
+        EXPECT_EQ(
+          extractMessageEventType(QJsonObject{
+            { "content", QJsonObject{ { "msgtype", "m.random" } } }, { "type", "m.room.message" },
+          }),
+          MessageEventType::Unknown);
 }


### PR DESCRIPTION
Fixes #71, #72, and partially #25.

There is now a "Leave room" option in the room menu (top-right corner, and in the right-click menu in the roomlist), which leaves the room.

Also, nheko now adds/removes rooms from the room list and room view when you join and leave rooms from another client.