### PR TITLE
Fixes #50.

### DIFF
--- a/include/TrayIcon.h
+++ b/include/TrayIcon.h
@@ -32,6 +32,8 @@ public:
 
         virtual void paint(QPainter *p, const QRect &rect, QIcon::Mode mode, QIcon::State state);
         virtual QIconEngine *clone() const;
+        virtual QList<QSize> availableSizes(QIcon::Mode mode, QIcon::State state) const;
+        virtual QPixmap pixmap(const QSize& size, QIcon::Mode mode, QIcon::State state);
 
         int msgCount = 0;
 

--- a/src/TrayIcon.cc
+++ b/src/TrayIcon.cc
@@ -17,6 +17,7 @@
 
 #include <QApplication>
 #include <QTimer>
+#include <QList>
 
 #include "TrayIcon.h"
 
@@ -70,6 +71,34 @@ QIconEngine *
 MsgCountComposedIcon::clone() const
 {
         return new MsgCountComposedIcon(*this);
+}
+
+QList<QSize>
+MsgCountComposedIcon::availableSizes(QIcon::Mode mode, QIcon::State state) const
+{
+        Q_UNUSED(mode);
+        Q_UNUSED(state);
+        QList<QSize> sizes;
+        sizes.append(QSize(24, 24));
+        sizes.append(QSize(32, 32));
+        sizes.append(QSize(48, 48));
+        sizes.append(QSize(64, 64));
+        sizes.append(QSize(128, 128));
+        sizes.append(QSize(256, 256));
+        return sizes;
+}
+
+QPixmap
+MsgCountComposedIcon::pixmap(const QSize& size, QIcon::Mode mode, QIcon::State state)
+{
+        QImage img(size, QImage::Format_ARGB32);
+        img.fill(qRgba(0, 0, 0, 0));
+        QPixmap result = QPixmap::fromImage(img, Qt::NoFormatConversion);
+        {
+                QPainter painter(&result);
+                paint(&painter, QRect(QPoint(0, 0), size), mode, state);
+        }
+        return result;
 }
 
 TrayIcon::TrayIcon(const QString &filename, QWidget *parent)


### PR DESCRIPTION
On KDE desktop icon failed to appear because TrayIcon requested a zero-size rect. Implementing MsgCountComposedIcon::availableSizes() method fixes that.

After icon became visible it was not transparent, and places that should have been transparent contained artifacts likely due to uninitialized memory. Implementing MsgCountComposedIcon::pixmap() which returns a pixmap with alpha channel fixes that.