### PR TITLE
Fix unicode handling of replaceEmoji

### DIFF
--- a/src/TimelineItem.cc
+++ b/src/TimelineItem.cc
@@ -371,17 +371,17 @@ TimelineItem::replaceEmoji(const QString &body)
 {
         QString fmtBody = "";
 
-        for (auto &c : body) {
-                int code = c.unicode();
+        QVector<uint> utf32_string = body.toUcs4();
 
+        for (auto &code : utf32_string) {
                 // TODO: Be more precise here.
                 if (code > 9000)
                         fmtBody += QString("<span style=\"font-family: Emoji "
                                            "One; font-size: %1px\">")
                                      .arg(conf::emojiSize) +
-                                   QString(c) + "</span>";
+                                   QString::fromUcs4(&code, 1) + "</span>";
                 else
-                        fmtBody += c;
+                        fmtBody += QString::fromUcs4(&code, 1);
         }
 
         return fmtBody;


### PR DESCRIPTION
`QString` is UTF-16 encoded, and iterating on it yields `QChar`, which are 16bits values, meaning in some cases iterating of the `QChar`s of a `QString` is not the good way to handle unicode codepoints (some emojis are encoded as a surrogate pair for example).

This fixes the `replaceEmoji` function to properly iterate on the unicode codepoints of the `QString`, rather than its `QChar`.

This removed from my nheko log a log of lines like

```
 4.440: [warning] - load glyph failed err=24 face=0x66e7b40, glyph=0
```

which were the result of `replaceEmoji` generating `QString`s with invalid UTF-16 data, and thus the font engine trying to load fonts for inexistant codepoints.

This can probably be done in a more optimized way (after all this new code starts by basically copying the input QString do re-encode it into UTF-32), but I couldn't find any clear way of doing so.