### PR TITLE
Fix sidebar resize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ set(SRC_FILES
     src/ui/Badge.cc
     src/ui/LoadingIndicator.cc
     src/ui/FlatButton.cc
+    src/ui/Label.cc
     src/ui/OverlayModal.cc
     src/ui/ScrollBar.cc
     src/ui/SnackBar.cc
@@ -250,6 +251,7 @@ qt5_wrap_cpp(MOC_HEADERS
     include/ui/Badge.h
     include/ui/LoadingIndicator.h
     include/ui/FlatButton.h
+    include/ui/Label.h
     include/ui/OverlayWidget.h
     include/ui/ScrollBar.h
     include/ui/SnackBar.h

--- a/include/TopRoomBar.h
+++ b/include/TopRoomBar.h
@@ -29,6 +29,7 @@
 
 #include "Avatar.h"
 #include "FlatButton.h"
+#include "Label.h"
 #include "LeaveRoomDialog.h"
 #include "Menu.h"
 #include "OverlayModal.h"
@@ -58,6 +59,7 @@ signals:
 
 protected:
         void paintEvent(QPaintEvent *event) override;
+        void mousePressEvent(QMouseEvent *event) override;
 
 private slots:
         void closeLeaveRoomDialog(bool leaving);
@@ -67,7 +69,7 @@ private:
         QVBoxLayout *textLayout_;
 
         QLabel *nameLabel_;
-        QLabel *topicLabel_;
+        Label *topicLabel_;
 
         QSharedPointer<RoomSettings> roomSettings_;
 
@@ -112,7 +114,6 @@ TopRoomBar::updateRoomName(const QString &name)
 inline void
 TopRoomBar::updateRoomTopic(QString topic)
 {
-        topic.replace(URL_REGEX, URL_HTML);
         roomTopic_ = topic;
         update();
 }

--- a/include/ui/Label.h
+++ b/include/ui/Label.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <QLabel>
+
+class Label : public QLabel
+{
+        Q_OBJECT
+
+public:
+        explicit Label(QWidget *parent = Q_NULLPTR, Qt::WindowFlags f = Qt::WindowFlags());
+        explicit Label(const QString &text,
+                       QWidget *parent   = Q_NULLPTR,
+                       Qt::WindowFlags f = Qt::WindowFlags());
+        ~Label() override {}
+
+signals:
+        void clicked(QMouseEvent *e);
+        void pressed(QMouseEvent *e);
+        void released(QMouseEvent *e);
+
+protected:
+        void mousePressEvent(QMouseEvent *e) override;
+        void mouseReleaseEvent(QMouseEvent *e) override;
+
+        QPoint pressPosition_;
+};

--- a/src/ui/Label.cc
+++ b/src/ui/Label.cc
@@ -1,0 +1,44 @@
+/*
+ * nheko Copyright (C) 2017  Konstantinos Sideris <siderisk@auth.gr>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Label.h"
+#include <QMouseEvent>
+
+Label::Label(QWidget *parent, Qt::WindowFlags f)
+  : QLabel(parent, f)
+{}
+
+Label::Label(const QString &text, QWidget *parent, Qt::WindowFlags f)
+  : QLabel(text, parent, f)
+{}
+
+void
+Label::mousePressEvent(QMouseEvent *e)
+{
+        pressPosition_ = e->pos();
+        emit pressed(e);
+        QLabel::mousePressEvent(e);
+}
+
+void
+Label::mouseReleaseEvent(QMouseEvent *e)
+{
+        emit released(e);
+        if (pressPosition_ == e->pos())
+                emit clicked(e);
+        QLabel::mouseReleaseEvent(e);
+}


### PR DESCRIPTION
Fixes #95 

Your previous commit did the trick. I made label to take (almost) entire width and expand/contract on left click. Resizing of sidebar now works equally good with short and long room topics.

Also fixed html formatting of elided text - html regex has to be applied after elision, otherwise label would attempt to display invalid html and spam console with errors. There is one problem remaining - if url is partially visible then clicking it would open url consisting of just visible part. It will do for now i guess.