### PR TITLE
Implement a setting for the tray icon

### DIFF
--- a/include/UserSettingsPage.h
+++ b/include/UserSettingsPage.h
@@ -66,6 +66,7 @@ protected:
 
 signals:
         void moveBack();
+        void trayOptionChanged(const bool value);
 
 private:
         // Layouts

--- a/include/UserSettingsPage.h
+++ b/include/UserSettingsPage.h
@@ -66,7 +66,7 @@ protected:
 
 signals:
         void moveBack();
-        void trayOptionChanged(const bool value);
+        void trayOptionChanged(bool value);
 
 private:
         // Layouts

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -113,6 +113,10 @@ MainWindow::MainWindow(QWidget *parent)
 
         QSettings settings;
 
+        if (!settings.value("user/window/tray", true).toBool()) {
+                trayIcon_->hide();
+        }
+
         if (hasActiveUser()) {
                 QString token       = settings.value("auth/access_token").toString();
                 QString home_server = settings.value("auth/home_server").toString();
@@ -253,7 +257,8 @@ MainWindow::showUserSettingsPage()
 void
 MainWindow::closeEvent(QCloseEvent *event)
 {
-        if (isVisible()) {
+        QSettings settings;
+        if (isVisible() && settings.value("user/window/tray", true).toBool()) {
                 event->ignore();
                 hide();
         }

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -94,9 +94,7 @@ MainWindow::MainWindow(QWidget *parent)
                 pageStack_->setCurrentWidget(chat_page_);
         });
 
-        connect(userSettingsPage_, &UserSettingsPage::trayOptionChanged, this, [=](const bool value) {
-                trayIcon_->setVisible(value);
-        });
+        connect(userSettingsPage_, SIGNAL(trayOptionChanged(bool)), trayIcon_, SLOT(setVisible(bool)));
 
         connect(trayIcon_,
                 SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
@@ -117,7 +115,7 @@ MainWindow::MainWindow(QWidget *parent)
 
         QSettings settings;
 
-        trayIcon_->setVisible(settings.value("user/window/tray", true).toBool());
+        trayIcon_->setVisible(userSettings_->isTrayEnabled());
 
         if (hasActiveUser()) {
                 QString token       = settings.value("auth/access_token").toString();
@@ -259,8 +257,7 @@ MainWindow::showUserSettingsPage()
 void
 MainWindow::closeEvent(QCloseEvent *event)
 {
-        QSettings settings;
-        if (isVisible() && settings.value("user/window/tray", true).toBool()) {
+        if (isVisible() && userSettings_->isTrayEnabled()) {
                 event->ignore();
                 hide();
         }

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -94,6 +94,10 @@ MainWindow::MainWindow(QWidget *parent)
                 pageStack_->setCurrentWidget(chat_page_);
         });
 
+        connect(userSettingsPage_, &UserSettingsPage::trayOptionChanged, this, [=](const bool value) {
+                trayIcon_->setVisible(value);
+        });
+
         connect(trayIcon_,
                 SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
                 this,
@@ -113,9 +117,7 @@ MainWindow::MainWindow(QWidget *parent)
 
         QSettings settings;
 
-        if (!settings.value("user/window/tray", true).toBool()) {
-                trayIcon_->hide();
-        }
+        trayIcon_->setVisible(settings.value("user/window/tray", true).toBool());
 
         if (hasActiveUser()) {
                 QString token       = settings.value("auth/access_token").toString();

--- a/src/TrayIcon.cc
+++ b/src/TrayIcon.cc
@@ -123,9 +123,6 @@ TrayIcon::TrayIcon(const QString &filename, QWidget *parent)
         menu->addAction(quitAction_);
 
         setContextMenu(menu);
-
-        // We wait a little for the icon to load.
-        QTimer::singleShot(500, this, [=]() { show(); });
 }
 
 void

--- a/src/UserSettingsPage.cc
+++ b/src/UserSettingsPage.cc
@@ -32,7 +32,7 @@ void
 UserSettings::load()
 {
         QSettings settings;
-        isTrayEnabled_ = settings.value("user/tray", true).toBool();
+        isTrayEnabled_ = settings.value("user/window/tray", true).toBool();
         theme_         = settings.value("user/theme", "default").toString();
 }
 
@@ -41,7 +41,11 @@ UserSettings::save()
 {
         QSettings settings;
         settings.beginGroup("user");
+
+        settings.beginGroup("window");
         settings.setValue("tray", isTrayEnabled_);
+        settings.endGroup();
+
         settings.setValue("theme", theme());
         settings.endGroup();
 }
@@ -122,8 +126,9 @@ UserSettingsPage::UserSettingsPage(QSharedPointer<UserSettings> settings, QWidge
                 static_cast<void (QComboBox::*)(const QString &)>(&QComboBox::activated),
                 [=](const QString &text) { settings_->setTheme(text.toLower()); });
 
-        connect(trayToggle_, &Toggle::toggled, this, [=](bool isEnabled) {
-                settings_->setTray(isEnabled);
+        connect(trayToggle_, &Toggle::toggled, this, [=](bool isDisabled) {
+                settings_->setTray(!isDisabled);
+                emit trayOptionChanged(!isDisabled);
         });
 
         connect(backBtn_, &QPushButton::clicked, this, [=]() {
@@ -136,5 +141,5 @@ void
 UserSettingsPage::showEvent(QShowEvent *)
 {
         themeCombo_->setCurrentIndex((settings_->theme() == "default" ? 0 : 1));
-        trayToggle_->setState(settings_->isTrayEnabled());
+        trayToggle_->setState(!settings_->isTrayEnabled()); // Treats true as "off"
 }


### PR DESCRIPTION
Adds an option `user/window/tray`. If that option is set to false, nheko exits when the window is closed. Defaults to true.

Signed-off-by: Jani Mustonen <janijohannes@kapsi.fi>