### PR TITLE
Improvements to the quick switcher

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -47,7 +47,6 @@ public:
 
 protected:
         void closeEvent(QCloseEvent *event);
-        void keyPressEvent(QKeyEvent *event);
 
 private slots:
         // Handle interaction with the tray icon.

--- a/include/TextInputWidget.h
+++ b/include/TextInputWidget.h
@@ -79,6 +79,9 @@ signals:
         void startedTyping();
         void stoppedTyping();
 
+protected:
+        void focusInEvent(QFocusEvent *event);
+
 private:
         void showUploadSpinner();
         QString parseEmoteCommand(const QString &cmd);

--- a/src/ChatPage.cc
+++ b/src/ChatPage.cc
@@ -562,6 +562,7 @@ ChatPage::showQuickSwitcher()
                 connect(quickSwitcher_.data(), &QuickSwitcher::closing, this, [=]() {
                         if (!this->quickSwitcherModal_.isNull())
                                 this->quickSwitcherModal_->fadeOut();
+                        this->text_input_->setFocus(Qt::FocusReason::PopupFocusReason);
                 });
         }
 
@@ -575,8 +576,12 @@ ChatPage::showQuickSwitcher()
 
         QMap<QString, QString> rooms;
 
-        for (auto it = state_manager_.constBegin(); it != state_manager_.constEnd(); ++it)
-                rooms.insert(it.value().getName(), it.key());
+        for (auto it = state_manager_.constBegin(); it != state_manager_.constEnd(); ++it) {
+                QString deambiguator = it.value().canonical_alias.content().alias();
+                if (deambiguator == "")
+                        deambiguator = it.key();
+                rooms.insert(it.value().getName() + " (" + deambiguator + ")", it.key());
+        }
 
         quickSwitcher_->setRoomList(rooms);
         quickSwitcherModal_->fadeIn();

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -111,6 +111,11 @@ MainWindow::MainWindow(QWidget *parent)
         QShortcut *quitShortcut = new QShortcut(QKeySequence::Quit, this);
         connect(quitShortcut, &QShortcut::activated, this, QApplication::quit);
 
+        QShortcut *quickSwitchShortcut = new QShortcut(QKeySequence("Ctrl+K"), this);
+        connect(quickSwitchShortcut, &QShortcut::activated, this, [=]() {
+                chat_page_->showQuickSwitcher();
+        });
+
         QSettings settings;
 
         if (hasActiveUser()) {
@@ -125,10 +130,7 @@ MainWindow::MainWindow(QWidget *parent)
 void
 MainWindow::keyPressEvent(QKeyEvent *e)
 {
-        if ((e->key() == Qt::Key_K) && (e->modifiers().testFlag(Qt::ControlModifier)))
-                chat_page_->showQuickSwitcher();
-        else
-                QMainWindow::keyPressEvent(e);
+        QMainWindow::keyPressEvent(e);
 }
 
 void

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -128,12 +128,6 @@ MainWindow::MainWindow(QWidget *parent)
 }
 
 void
-MainWindow::keyPressEvent(QKeyEvent *e)
-{
-        QMainWindow::keyPressEvent(e);
-}
-
-void
 MainWindow::restoreWindowSize()
 {
         QSettings settings;

--- a/src/QuickSwitcher.cc
+++ b/src/QuickSwitcher.cc
@@ -122,7 +122,16 @@ QuickSwitcher::QuickSwitcher(QWidget *parent)
           roomSearch_, &RoomSearchInput::hiding, this, [=]() { completer_->popup()->hide(); });
         connect(roomSearch_, &QLineEdit::returnPressed, this, [=]() {
                 emit closing();
-                emit roomSelected(rooms_[this->roomSearch_->text().trimmed()]);
+
+                QString text("");
+
+                if (selection_ == -1) {
+                        completer_->setCurrentRow(0);
+                        text = completer_->currentCompletion();
+                } else {
+                        text = this->roomSearch_->text().trimmed();
+                }
+                emit roomSelected(rooms_[text]);
 
                 roomSearch_->clear();
         });

--- a/src/TextInputWidget.cc
+++ b/src/TextInputWidget.cc
@@ -259,3 +259,9 @@ TextInputWidget::stopTyping()
 {
         input_->stopTyping();
 }
+
+void
+TextInputWidget::focusInEvent(QFocusEvent *event)
+{
+        input_->setFocus(event->reason());
+}


### PR DESCRIPTION
Added a simple disambiguation to the room switcher.
Fixed ctrl+k (it got grabbed by the text input).
Fixed keyboard focus after closing the quick switcher (now automatically focuses the text input).