### PR TITLE
Update clang and Ubuntu 14.04 instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ sudo emerge -a nheko
 - CMake 3.1 or greater.
 - [LMDB](https://symas.com/lightning-memory-mapped-database/).
 - A compiler that supports C++11.
-    - Clang 3.3 (or greater).
+    - Clang 3.6 (or greater).
     - GCC 4.9.4 (or greater).
 
 ##### Arch Linux
@@ -69,6 +69,15 @@ sudo add-apt-repository ppa:george-edison55/cmake-3.x
 sudo apt-get update
 sudo apt-get install -y qt59base qt59tools qt59multimedia cmake liblmdb-dev
 ```
+
+To build on Ubuntu 14.04 Trusty out-of-the-box requires using Clang 3.6 instead of GCC:
+
+```bash
+sudo apt-get install clang-3.6
+export CC=clang-3.6 CXX=clang++-3.6
+```
+
+On Ubuntu 14.04 Trusty, it's possible to use GCC 4.9.4+, but it is not recommended, because it requires installing GCC packages from third-party PPAs.  Later versions of Ubuntu that come with GCC 4.9.4+ should work with GCC out-of-the-box.
 
 ##### OSX (Xcode 8 or later)
 


### PR DESCRIPTION
On Ubuntu 14.04, Clang 3.6 is the minimum version, and seems to be the only way to build nheko out-of-the-box.  Using GCC on this version of Ubuntu requires installing newer GCC packages from third-party PPAs, which is quite messy and not generally recommended.