### PR TITLE
filter content in sync that is currently unhandled

### DIFF
--- a/include/MatrixClient.h
+++ b/include/MatrixClient.h
@@ -159,4 +159,7 @@ private:
 
         // Token to be used for the next sync.
         QString next_batch_;
+
+	// filter to be send as filter-param for (initial) /sync requests
+	QString filter_;
 };

--- a/src/MatrixClient.cc
+++ b/src/MatrixClient.cc
@@ -198,13 +198,31 @@ MatrixClient::sync() noexcept
           {"room",
            QJsonObject{
              {"include_leave", true},
-           }},
+             {"account_data",
+               QJsonObject{
+                 {"not_types", QJsonArray{"*"}},
+               },
+             },{"ephemeral",
+               QJsonObject{
+                 {"types", QJsonArray{"m.receipt","m.typing"}},
+               },
+             },
+           },
+          },{"account_data",
+            QJsonObject{
+              {"not_types", QJsonArray{"*"}},
+            },
+          },{"presence",
+            QJsonObject{
+              {"not_types", QJsonArray{"*"}},
+            },
+          },
         };
 
         QUrlQuery query;
         query.addQueryItem("set_presence", "online");
         query.addQueryItem("filter", QJsonDocument(filter).toJson(QJsonDocument::Compact));
-        query.addQueryItem("timeout", "15000");
+        query.addQueryItem("timeout", "30000");
         query.addQueryItem("access_token", token_);
 
         if (next_batch_.isEmpty()) {

--- a/src/MatrixClient.cc
+++ b/src/MatrixClient.cc
@@ -202,10 +202,6 @@ MatrixClient::sync() noexcept
                QJsonObject{
                  {"not_types", QJsonArray{"*"}},
                },
-             },{"ephemeral",
-               QJsonObject{
-                 {"types", QJsonArray{"m.receipt","m.typing"}},
-               },
              },
            },
           },{"account_data",

--- a/src/MatrixClient.cc
+++ b/src/MatrixClient.cc
@@ -41,6 +41,32 @@ MatrixClient::MatrixClient(QString server, QObject *parent)
         QSettings settings;
         txn_id_ = settings.value("client/transaction_id", 1).toInt();
 
+        QJsonObject default_filter{
+          {"room",
+           QJsonObject{
+             {"include_leave", true},
+             {"account_data",
+               QJsonObject{
+                 {"not_types", QJsonArray{"*"}},
+               },
+             },
+           },
+          },{"account_data",
+            QJsonObject{
+              {"not_types", QJsonArray{"*"}},
+            },
+          },{"presence",
+            QJsonObject{
+              {"not_types", QJsonArray{"*"}},
+            },
+          },
+        };
+
+	filter_ = settings.value(
+            "client/sync_filter",
+            QJsonDocument(default_filter).toJson(QJsonDocument::Compact)
+        ).toString();
+
         connect(this,
                 &QNetworkAccessManager::networkAccessibleChanged,
                 this,
@@ -194,30 +220,9 @@ MatrixClient::registerUser(const QString &user, const QString &pass, const QStri
 void
 MatrixClient::sync() noexcept
 {
-        QJsonObject filter{
-          {"room",
-           QJsonObject{
-             {"include_leave", true},
-             {"account_data",
-               QJsonObject{
-                 {"not_types", QJsonArray{"*"}},
-               },
-             },
-           },
-          },{"account_data",
-            QJsonObject{
-              {"not_types", QJsonArray{"*"}},
-            },
-          },{"presence",
-            QJsonObject{
-              {"not_types", QJsonArray{"*"}},
-            },
-          },
-        };
-
         QUrlQuery query;
         query.addQueryItem("set_presence", "online");
-        query.addQueryItem("filter", QJsonDocument(filter).toJson(QJsonDocument::Compact));
+        query.addQueryItem("filter", filter_);
         query.addQueryItem("timeout", "30000");
         query.addQueryItem("access_token", token_);
 
@@ -349,6 +354,7 @@ MatrixClient::initialSync() noexcept
 {
         QUrlQuery query;
         query.addQueryItem("timeout", "0");
+        query.addQueryItem("filter", filter_);
         query.addQueryItem("access_token", token_);
 
         QUrl endpoint(server_);


### PR DESCRIPTION
I had a look at sync.cpp and checked which parts of the sync response
are currently handled and which not.
As I think it is unneccessary to let the unhandled data be transmitted
without beeing handled I added these filters.

In the same term I increased the timeout server-side to 30s as Riot
defaults to this value as well.
Especially now when a lots of presence-updates are not send anymore
this value is more relevant