### PR TITLE
Upload filter automatically and use filter_id

### DIFF
--- a/include/MatrixClient.h
+++ b/include/MatrixClient.h
@@ -161,6 +161,6 @@ private:
         // Token to be used for the next sync.
         QString next_batch_;
 
-	// filter to be send as filter-param for (initial) /sync requests
-	QString filter_;
+        // filter to be send as filter-param for (initial) /sync requests
+        QString filter_;
 };

--- a/include/MatrixClient.h
+++ b/include/MatrixClient.h
@@ -64,6 +64,7 @@ public:
         void uploadAudio(const QString &roomid,
                          const QSharedPointer<QIODevice> data,
                          const QString &filename);
+        void uploadFilter(const QString &filter) noexcept;
         void joinRoom(const QString &roomIdOrAlias);
         void leaveRoom(const QString &roomId);
         void sendTypingNotification(const QString &roomid, int timeoutInMillis = 20000);

--- a/include/MatrixClient.h
+++ b/include/MatrixClient.h
@@ -160,6 +160,6 @@ private:
         // Token to be used for the next sync.
         QString next_batch_;
 
-        // filter to be send as filter-param for (initial) /sync requests
-        QString filter_;
+	// filter to be send as filter-param for (initial) /sync requests
+	QString filter_;
 };

--- a/src/MatrixClient.cc
+++ b/src/MatrixClient.cc
@@ -42,30 +42,36 @@ MatrixClient::MatrixClient(QString server, QObject *parent)
         txn_id_ = settings.value("client/transaction_id", 1).toInt();
 
         QJsonObject default_filter{
-          {"room",
-           QJsonObject{
-             {"include_leave", true},
-             {"account_data",
-               QJsonObject{
-                 {"not_types", QJsonArray{"*"}},
-               },
-             },
-           },
-          },{"account_data",
+          {
+            "room",
+            QJsonObject{
+              {"include_leave", true},
+              {
+                "account_data",
+                QJsonObject{
+                  {"not_types", QJsonArray{"*"}},
+                },
+              },
+            },
+          },
+          {
+            "account_data",
             QJsonObject{
               {"not_types", QJsonArray{"*"}},
             },
-          },{"presence",
+          },
+          {
+            "presence",
             QJsonObject{
               {"not_types", QJsonArray{"*"}},
             },
           },
         };
 
-	filter_ = settings.value(
-            "client/sync_filter",
-            QJsonDocument(default_filter).toJson(QJsonDocument::Compact)
-        ).toString();
+        filter_ = settings
+                    .value("client/sync_filter",
+                           QJsonDocument(default_filter).toJson(QJsonDocument::Compact))
+                    .toString();
 
         connect(this,
                 &QNetworkAccessManager::networkAccessibleChanged,

--- a/src/MatrixClient.cc
+++ b/src/MatrixClient.cc
@@ -220,6 +220,13 @@ MatrixClient::registerUser(const QString &user, const QString &pass, const QStri
 void
 MatrixClient::sync() noexcept
 {
+        // the filter is not uploaded yet (so it is a json with { at the beginning)
+        // ignore for now that the filter might be uploaded multiple times as we expect
+        // servers to do deduplication
+        if (filter_.startsWith("{")) {
+                uploadFilter(filter_);
+        }
+
         QUrlQuery query;
         query.addQueryItem("set_presence", "online");
         query.addQueryItem("filter", filter_);
@@ -958,6 +965,55 @@ MatrixClient::uploadAudio(const QString &roomid,
                 }
 
                 emit audioUploaded(roomid, filename, object.value("content_uri").toString());
+        });
+}
+
+void
+MatrixClient::uploadFilter(const QString &filter) noexcept
+{
+        // validate that filter is a Json-String
+        QJsonDocument doc = QJsonDocument::fromJson(filter.toUtf8());
+        if (doc.isNull() || !doc.isObject()) {
+                qWarning() << "Input which should be uploaded as filter is no JsonObject";
+                return;
+        }
+
+        QSettings settings;
+        auto userid = settings.value("auth/user_id", "").toString();
+
+        QUrlQuery query;
+        query.addQueryItem("access_token", token_);
+
+        QUrl endpoint(server_);
+        endpoint.setPath(clientApiUrl_ + QString("/user/%1/filter").arg(userid));
+        endpoint.setQuery(query);
+
+        QNetworkRequest request(endpoint);
+        request.setHeader(QNetworkRequest::KnownHeaders::ContentTypeHeader, "application/json");
+
+        auto reply = post(request, doc.toJson(QJsonDocument::Compact));
+
+        connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+                reply->deleteLater();
+
+                int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+
+                if (status == 0 || status >= 400) {
+                        qWarning() << reply->errorString() << "42";
+                        return;
+                }
+
+                auto data      = reply->readAll();
+                auto response  = QJsonDocument::fromJson(data);
+                auto filter_id = response.object()["filter_id"].toString();
+
+                qDebug() << "Filter with ID" << filter_id << "created.";
+                QSettings settings;
+                settings.setValue("client/sync_filter", filter_id);
+                settings.sync();
+
+                // set the filter_ var so following syncs will use it
+                filter_ = filter_id;
         });
 }
 

--- a/src/MatrixClient.cc
+++ b/src/MatrixClient.cc
@@ -42,36 +42,30 @@ MatrixClient::MatrixClient(QString server, QObject *parent)
         txn_id_ = settings.value("client/transaction_id", 1).toInt();
 
         QJsonObject default_filter{
-          {
-            "room",
-            QJsonObject{
-              {"include_leave", true},
-              {
-                "account_data",
-                QJsonObject{
-                  {"not_types", QJsonArray{"*"}},
-                },
-              },
-            },
-          },
-          {
-            "account_data",
+          {"room",
+           QJsonObject{
+             {"include_leave", true},
+             {"account_data",
+               QJsonObject{
+                 {"not_types", QJsonArray{"*"}},
+               },
+             },
+           },
+          },{"account_data",
             QJsonObject{
               {"not_types", QJsonArray{"*"}},
             },
-          },
-          {
-            "presence",
+          },{"presence",
             QJsonObject{
               {"not_types", QJsonArray{"*"}},
             },
           },
         };
 
-        filter_ = settings
-                    .value("client/sync_filter",
-                           QJsonDocument(default_filter).toJson(QJsonDocument::Compact))
-                    .toString();
+	filter_ = settings.value(
+            "client/sync_filter",
+            QJsonDocument(default_filter).toJson(QJsonDocument::Compact)
+        ).toString();
 
         connect(this,
                 &QNetworkAccessManager::networkAccessibleChanged,


### PR DESCRIPTION
When a custom filter is inserted into nheko.conf or there was no filter
defined yet the default filter gets automatically uploaded.
After a successful upload the server-side generated filter-id is used.

This is done async as it is just an enhancement and it is not required
to upload the filter before the first request.