### PR TITLE
Fix #217: create space for checkmark beforehand

### DIFF
--- a/include/timeline/TimelineItem.h
+++ b/include/timeline/TimelineItem.h
@@ -137,6 +137,7 @@ private:
         QFont font_;
 
         QLabel *timestamp_;
+        QLabel *checkmark_;
         QLabel *userName_;
         QLabel *body_;
 };

--- a/include/timeline/TimelineItem.h
+++ b/include/timeline/TimelineItem.h
@@ -182,6 +182,7 @@ TimelineItem::setupLocalWidgetLayout(Widget *widget,
                 messageLayout_->addLayout(widgetLayout, 1);
         }
 
+        messageLayout_->addWidget(checkmark_);
         messageLayout_->addWidget(timestamp_);
         mainLayout_->addLayout(messageLayout_);
 }
@@ -232,6 +233,7 @@ TimelineItem::setupWidgetLayout(Widget *widget,
                 messageLayout_->addLayout(widgetLayout, 1);
         }
 
+        messageLayout_->addWidget(checkmark_);
         messageLayout_->addWidget(timestamp_);
         mainLayout_->addLayout(messageLayout_);
 }

--- a/src/timeline/TimelineItem.cc
+++ b/src/timeline/TimelineItem.cc
@@ -61,6 +61,10 @@ TimelineItem::init()
 
         mainLayout_->setContentsMargins(conf::timeline::headerLeftMargin, 0, 0, 0);
         mainLayout_->setSpacing(0);
+
+        checkmark_ = new QLabel(" ", this);
+        checkmark_->setStyleSheet(
+          QString("font-size: %1px;").arg(conf::timeline::fonts::timestamp));
 }
 
 /*
@@ -108,6 +112,7 @@ TimelineItem::TimelineItem(mtx::events::MessageType ty,
                 messageLayout_->addWidget(body_, 1);
         }
 
+        messageLayout_->addWidget(checkmark_);
         messageLayout_->addWidget(timestamp_);
         mainLayout_->addLayout(messageLayout_);
 }
@@ -239,6 +244,7 @@ TimelineItem::TimelineItem(const mtx::events::RoomEvent<mtx::events::msg::Notice
                 messageLayout_->addWidget(body_, 1);
         }
 
+        messageLayout_->addWidget(checkmark_);
         messageLayout_->addWidget(timestamp_);
         mainLayout_->addLayout(messageLayout_);
 }
@@ -285,6 +291,7 @@ TimelineItem::TimelineItem(const mtx::events::RoomEvent<mtx::events::msg::Emote>
                 messageLayout_->addWidget(body_, 1);
         }
 
+        messageLayout_->addWidget(checkmark_);
         messageLayout_->addWidget(timestamp_);
         mainLayout_->addLayout(messageLayout_);
 }
@@ -336,6 +343,7 @@ TimelineItem::TimelineItem(const mtx::events::RoomEvent<mtx::events::msg::Text> 
                 messageLayout_->addWidget(body_, 1);
         }
 
+        messageLayout_->addWidget(checkmark_);
         messageLayout_->addWidget(timestamp_);
         mainLayout_->addLayout(messageLayout_);
 }
@@ -343,11 +351,8 @@ TimelineItem::TimelineItem(const mtx::events::RoomEvent<mtx::events::msg::Text> 
 void
 TimelineItem::markReceived()
 {
-        auto checkmark = new QLabel("✓", this);
-        checkmark->setStyleSheet(QString("font-size: %1px;").arg(conf::timeline::fonts::timestamp));
-        checkmark->setAlignment(Qt::AlignTop);
-
-        messageLayout_->insertWidget(1, checkmark);
+        checkmark_->setText("✓");
+        checkmark_->setAlignment(Qt::AlignTop);
 }
 
 // Only the body is displayed.

--- a/src/timeline/TimelineItem.cc
+++ b/src/timeline/TimelineItem.cc
@@ -64,13 +64,14 @@ TimelineItem::init()
         mainLayout_->setContentsMargins(conf::timeline::headerLeftMargin, 0, 0, 0);
         mainLayout_->setSpacing(0);
 
+        QFont checkmarkFont;
+        checkmarkFont.setPixelSize(conf::timeline::fonts::timestamp);
+
         // Setting fixed width for checkmark because systems may have a differing width for a
         // space and the Unicode checkmark.
         checkmark_ = new QLabel(" ", this);
-        checkmark_->setFixedWidth(fm.width(CHECKMARK));
-        checkmark_->setFont(font_);
-        checkmark_->setStyleSheet(
-          QString("font-size: %1px;").arg(conf::timeline::fonts::timestamp));
+        checkmark_->setFont(checkmarkFont);
+        checkmark_->setFixedWidth(QFontMetrics{checkmarkFont}.width(CHECKMARK));
 }
 
 /*

--- a/src/timeline/TimelineItem.cc
+++ b/src/timeline/TimelineItem.cc
@@ -30,6 +30,8 @@
 #include "timeline/widgets/ImageItem.h"
 #include "timeline/widgets/VideoItem.h"
 
+constexpr const static char *CHECKMARK = "✓";
+
 void
 TimelineItem::init()
 {
@@ -62,7 +64,11 @@ TimelineItem::init()
         mainLayout_->setContentsMargins(conf::timeline::headerLeftMargin, 0, 0, 0);
         mainLayout_->setSpacing(0);
 
+        // Setting fixed width for checkmark because systems may have a differing width for a
+        // space and the Unicode checkmark.
         checkmark_ = new QLabel(" ", this);
+        checkmark_->setFixedWidth(fm.width(CHECKMARK));
+        checkmark_->setFont(font_);
         checkmark_->setStyleSheet(
           QString("font-size: %1px;").arg(conf::timeline::fonts::timestamp));
 }
@@ -351,7 +357,7 @@ TimelineItem::TimelineItem(const mtx::events::RoomEvent<mtx::events::msg::Text> 
 void
 TimelineItem::markReceived()
 {
-        checkmark_->setText("✓");
+        checkmark_->setText(CHECKMARK);
         checkmark_->setAlignment(Qt::AlignTop);
 }
 


### PR DESCRIPTION
Allocates a " " (space character) to be a placeholder until the message is verifiably received on the other side. This seems to fix the issue because the checkmark was previously being inserted into the layout at run-time, which would move other push the widgets surrounding it. 