### PR TITLE
Updated Fedora installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ pacaur -S nheko-git
 
 #### Fedora
 ```bash
-sudo dnf copr enable xvitaly/matrix
 sudo dnf install nheko
 ```
 


### PR DESCRIPTION
nheko is now available from Fedora's main repositories.