### PR TITLE
Add support for read room access

### DIFF
--- a/include/Cache.h
+++ b/include/Cache.h
@@ -23,6 +23,8 @@
 #include <json.hpp>
 #include <lmdb++.h>
 #include <mtx/responses.hpp>
+#include <mtx/events/join_rules.hpp>
+using mtx::events::state::JoinRule;
 
 struct RoomMember
 {
@@ -74,6 +76,9 @@ struct RoomInfo
         bool is_invite = false;
         //! Total number of members in the room.
         int16_t member_count = 0;
+        //! Who can access to the room.
+        JoinRule join_rule = JoinRule::Public;
+        bool guest_access = false;
 };
 
 inline void
@@ -164,6 +169,9 @@ public:
 
         //! Calculate & return the name of the room.
         QString getRoomName(lmdb::txn &txn, lmdb::dbi &statesdb, lmdb::dbi &membersdb);
+        //! Get room join rules
+        JoinRule getRoomJoinRules(lmdb::txn &txn, lmdb::dbi &statesdb);
+        bool getRoomGuestAccess(lmdb::txn &txn, lmdb::dbi &statesdb);
         //! Retrieve the topic of the room if any.
         QString getRoomTopic(lmdb::txn &txn, lmdb::dbi &statesdb);
         //! Retrieve the room avatar's url if any.

--- a/include/Cache.h
+++ b/include/Cache.h
@@ -22,8 +22,8 @@
 #include <QImage>
 #include <json.hpp>
 #include <lmdb++.h>
-#include <mtx/responses.hpp>
 #include <mtx/events/join_rules.hpp>
+#include <mtx/responses.hpp>
 using mtx::events::state::JoinRule;
 
 struct RoomMember
@@ -78,7 +78,7 @@ struct RoomInfo
         int16_t member_count = 0;
         //! Who can access to the room.
         JoinRule join_rule = JoinRule::Public;
-        bool guest_access = false;
+        bool guest_access  = false;
 };
 
 inline void

--- a/include/Cache.h
+++ b/include/Cache.h
@@ -84,10 +84,12 @@ struct RoomInfo
 inline void
 to_json(json &j, const RoomInfo &info)
 {
-        j["name"]       = info.name;
-        j["topic"]      = info.topic;
-        j["avatar_url"] = info.avatar_url;
-        j["is_invite"]  = info.is_invite;
+        j["name"]         = info.name;
+        j["topic"]        = info.topic;
+        j["avatar_url"]   = info.avatar_url;
+        j["is_invite"]    = info.is_invite;
+        j["join_rule"]    = info.join_rule;
+        j["guest_access"] = info.guest_access;
 
         if (info.member_count != 0)
                 j["member_count"] = info.member_count;
@@ -96,10 +98,12 @@ to_json(json &j, const RoomInfo &info)
 inline void
 from_json(const json &j, RoomInfo &info)
 {
-        info.name       = j.at("name");
-        info.topic      = j.at("topic");
-        info.avatar_url = j.at("avatar_url");
-        info.is_invite  = j.at("is_invite");
+        info.name         = j.at("name");
+        info.topic        = j.at("topic");
+        info.avatar_url   = j.at("avatar_url");
+        info.is_invite    = j.at("is_invite");
+        info.join_rule    = j.at("join_rule");
+        info.guest_access = j.at("guest_access");
 
         if (j.count("member_count"))
                 info.member_count = j.at("member_count");
@@ -170,7 +174,7 @@ public:
         //! Calculate & return the name of the room.
         QString getRoomName(lmdb::txn &txn, lmdb::dbi &statesdb, lmdb::dbi &membersdb);
         //! Get room join rules
-        JoinRule getRoomJoinRules(lmdb::txn &txn, lmdb::dbi &statesdb);
+        JoinRule getRoomJoinRule(lmdb::txn &txn, lmdb::dbi &statesdb);
         bool getRoomGuestAccess(lmdb::txn &txn, lmdb::dbi &statesdb);
         //! Retrieve the topic of the room if any.
         QString getRoomTopic(lmdb::txn &txn, lmdb::dbi &statesdb);

--- a/include/dialogs/RoomSettings.hpp
+++ b/include/dialogs/RoomSettings.hpp
@@ -11,6 +11,7 @@ class Avatar;
 class QPixmap;
 class QLayout;
 class QLabel;
+class QComboBox;
 
 template<class T>
 class QSharedPointer;
@@ -67,6 +68,9 @@ signals:
 protected:
         void paintEvent(QPaintEvent *event) override;
 
+private slots:
+        void save_and_close();
+
 private:
         static constexpr int AvatarSize = 64;
 
@@ -79,6 +83,8 @@ private:
         RoomInfo info_;
         QString room_id_;
         QImage avatarImg_;
+
+        QComboBox *accessCombo;
 };
 
 } // dialogs

--- a/src/Cache.cc
+++ b/src/Cache.cc
@@ -826,8 +826,7 @@ Cache::getRoomJoinRule(lmdb::txn &txn, lmdb::dbi &statesdb)
                         StateEvent<JoinRules> msg =
                           json::parse(std::string(event.data(), event.size()));
                         return msg.content.join_rule;
-                }
-                catch (const json::exception &e) {
+                } catch (const json::exception &e) {
                         qWarning() << e.what();
                 }
         }

--- a/src/Cache.cc
+++ b/src/Cache.cc
@@ -550,8 +550,8 @@ Cache::roomsWithStateUpdates(const mtx::responses::Sync &res)
 RoomInfo
 Cache::singleRoomInfo(const std::string &room_id)
 {
-        auto txn = lmdb::txn::begin(env_, nullptr, MDB_RDONLY);
-        auto statesdb  = getStatesDb(txn, room_id);
+        auto txn      = lmdb::txn::begin(env_, nullptr, MDB_RDONLY);
+        auto statesdb = getStatesDb(txn, room_id);
 
         lmdb::val data;
 
@@ -560,7 +560,7 @@ Cache::singleRoomInfo(const std::string &room_id)
                 try {
                         RoomInfo tmp     = json::parse(std::string(data.data(), data.size()));
                         tmp.member_count = getMembersDb(txn, room_id).size(txn);
-                        tmp.join_rule = getRoomJoinRule(txn, statesdb);
+                        tmp.join_rule    = getRoomJoinRule(txn, statesdb);
                         tmp.guest_access = getRoomGuestAccess(txn, statesdb);
 
                         txn.commit();
@@ -587,14 +587,14 @@ Cache::getRoomInfo(const std::vector<std::string> &rooms)
 
         for (const auto &room : rooms) {
                 lmdb::val data;
-                auto statesdb  = getStatesDb(txn, room);
+                auto statesdb = getStatesDb(txn, room);
 
                 // Check if the room is joined.
                 if (lmdb::dbi_get(txn, roomsDb_, lmdb::val(room), data)) {
                         try {
                                 RoomInfo tmp = json::parse(std::string(data.data(), data.size()));
                                 tmp.member_count = getMembersDb(txn, room).size(txn);
-                                tmp.join_rule = getRoomJoinRule(txn, statesdb);
+                                tmp.join_rule    = getRoomJoinRule(txn, statesdb);
                                 tmp.guest_access = getRoomGuestAccess(txn, statesdb);
 
                                 room_info.emplace(QString::fromStdString(room), std::move(tmp));
@@ -823,7 +823,8 @@ Cache::getRoomJoinRule(lmdb::txn &txn, lmdb::dbi &statesdb)
 
         if (res) {
                 try {
-                        StateEvent<JoinRules> msg = json::parse(std::string(event.data(), event.size()));
+                        StateEvent<JoinRules> msg =
+                          json::parse(std::string(event.data(), event.size()));
                         return msg.content.join_rule;
                 }
                 catch (const json::exception &e) {
@@ -845,10 +846,10 @@ Cache::getRoomGuestAccess(lmdb::txn &txn, lmdb::dbi &statesdb)
 
         if (res) {
                 try {
-                        StateEvent<GuestAccess> msg = json::parse(std::string(event.data(), event.size()));
+                        StateEvent<GuestAccess> msg =
+                          json::parse(std::string(event.data(), event.size()));
                         return msg.content.guest_access == AccessState::CanJoin;
-                }
-                catch (const json::exception &e) {
+                } catch (const json::exception &e) {
                         qWarning() << e.what();
                 }
         }

--- a/src/dialogs/RoomSettings.cpp
+++ b/src/dialogs/RoomSettings.cpp
@@ -59,13 +59,59 @@ RoomSettings::RoomSettings(const QString &room_id, QWidget *parent)
         notifOptionLayout_->addWidget(notifLabel);
         notifOptionLayout_->addWidget(notifCombo, 0, Qt::AlignBottom | Qt::AlignRight);
 
+        auto accessOptionLayout = new QHBoxLayout();
+        accessOptionLayout->setMargin(5);
+        auto accessLabel = new QLabel(tr("Room access"), this);
+        accessCombo = new QComboBox(this);
+        accessCombo->addItem(tr("Anyone and guests"));
+        accessCombo->addItem(tr("Anyone"));
+        accessCombo->addItem(tr("Inviteds"));
+        accessCombo->setDisabled(true);
+        accessLabel->setStyleSheet("font-size: 15px;");
+
+        if(info_.join_rule == JoinRule::Public)
+                if(info_.guest_access)
+                        accessCombo->setCurrentIndex(0);
+                else
+                        accessCombo->setCurrentIndex(1);
+        else
+                accessCombo->setCurrentIndex(2);
+
+        accessOptionLayout->addWidget(accessLabel);
+        accessOptionLayout->addWidget(accessCombo);
+
         layout->addWidget(new TopSection(info_, avatarImg_, this));
         layout->addLayout(notifOptionLayout_);
         layout->addLayout(notifOptionLayout_);
+        layout->addLayout(accessOptionLayout);
         layout->addLayout(btnLayout);
 
         connect(cancelBtn_, &FlatButton::clicked, this, &RoomSettings::closing);
-        connect(saveBtn_, &FlatButton::clicked, this, [this]() { emit closing(); });
+        connect(saveBtn_, &FlatButton::clicked, this, &RoomSettings::save_and_close);
+}
+
+void
+RoomSettings::save_and_close() {
+        // TODO: Save access changes to the room
+        if (accessCombo->currentIndex()<2) {
+                if(info_.join_rule != JoinRule::Public) {
+                        // Make join_rule Public
+                }
+                if(accessCombo->currentIndex()==0) {
+                        if(!info_.guest_access) {
+                                // Make guest_access CanJoin
+                        }
+                }
+        }
+        else {
+                if(info_.join_rule != JoinRule::Invite) {
+                        // Make join_rule invite
+                }
+                if(info_.guest_access) {
+                        // Make guest_access forbidden
+                }
+        }
+        closing();
 }
 
 void

--- a/src/dialogs/RoomSettings.cpp
+++ b/src/dialogs/RoomSettings.cpp
@@ -64,17 +64,25 @@ RoomSettings::RoomSettings(const QString &room_id, QWidget *parent)
         accessCombo = new QComboBox(this);
         accessCombo->addItem(tr("Anyone and guests"));
         accessCombo->addItem(tr("Anyone"));
-        accessCombo->addItem(tr("Inviteds"));
+        accessCombo->addItem(tr("Invited users"));
         accessCombo->setDisabled(true);
         accessLabel->setStyleSheet("font-size: 15px;");
 
         if(info_.join_rule == JoinRule::Public)
+        {
                 if(info_.guest_access)
+                {
                         accessCombo->setCurrentIndex(0);
+                }
                 else
+                {
                         accessCombo->setCurrentIndex(1);
+                }
+        }
         else
+        {
                 accessCombo->setCurrentIndex(2);
+        }
 
         accessOptionLayout->addWidget(accessLabel);
         accessOptionLayout->addWidget(accessCombo);

--- a/src/dialogs/RoomSettings.cpp
+++ b/src/dialogs/RoomSettings.cpp
@@ -22,8 +22,7 @@ RoomSettings::RoomSettings(const QString &room_id, QWidget *parent)
         setMaximumWidth(385);
 
         try {
-                auto res = cache::client()->getRoomInfo({room_id_.toStdString()});
-                info_    = res[room_id_];
+                info_ = cache::client()->singleRoomInfo(room_id_.toStdString());
 
                 setAvatar(QImage::fromData(cache::client()->image(info_.avatar_url)));
         } catch (const lmdb::error &e) {

--- a/src/timeline/widgets/ImageItem.cc
+++ b/src/timeline/widgets/ImageItem.cc
@@ -183,7 +183,7 @@ ImageItem::paintEvent(QPaintEvent *event)
         if (image_.isNull()) {
                 QString elidedText = metrics.elidedText(text_, Qt::ElideRight, max_width_ - 10);
 
-                setFixedSize(qMax(max_width_, metrics.width(elidedText)), qMax(max_height_, fontHeight));
+                setFixedSize(metrics.width(elidedText), fontHeight);
 
                 painter.setFont(font);
                 painter.setPen(QPen(QColor(66, 133, 244)));

--- a/src/timeline/widgets/ImageItem.cc
+++ b/src/timeline/widgets/ImageItem.cc
@@ -183,7 +183,7 @@ ImageItem::paintEvent(QPaintEvent *event)
         if (image_.isNull()) {
                 QString elidedText = metrics.elidedText(text_, Qt::ElideRight, max_width_ - 10);
 
-                setFixedSize(metrics.width(elidedText), fontHeight);
+                setFixedSize(qMax(max_width_, metrics.width(elidedText)), qMax(max_height_, fontHeight));
 
                 painter.setFont(font);
                 painter.setPen(QPen(QColor(66, 133, 244)));


### PR DESCRIPTION
In Room settings you can see who can join to the room, whether it's just the inviteds, anyone or anyone including guests.

I would have liked to implement the possibility of changing it, but I am not familiar with the source code and I did not find a similar function with which I could be oriented.