### PR TITLE
State that encrypted attachments aren't supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ feels more like a mainstream chat app ([Riot], Telegram etc) and less like an IR
 Most of the features you would expect from a chat application are missing right now
 but we are getting close to a more feature complete client.
 Specifically there is support for:
-- E2E encryption (text messages only: attachments are currently sent unencrypted).
+- E2E encryption( text messages only: attachments are currently sent unencrypted).
 - User registration.
 - Creating, joining & leaving rooms.
 - Sending & receiving invites.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ feels more like a mainstream chat app ([Riot], Telegram etc) and less like an IR
 Most of the features you would expect from a chat application are missing right now
 but we are getting close to a more feature complete client.
 Specifically there is support for:
-- E2E encryption( text messages only: attachments are currently sent unencrypted).
+- E2E encryption (text messages only: attachments are currently sent unencrypted).
 - User registration.
 - Creating, joining & leaving rooms.
 - Sending & receiving invites.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ feels more like a mainstream chat app ([Riot], Telegram etc) and less like an IR
 Most of the features you would expect from a chat application are missing right now
 but we are getting close to a more feature complete client.
 Specifically there is support for:
-- E2E encryption.
+- E2E encryption (text messages only: attachments are currently sent unencrypted).
 - User registration.
 - Creating, joining & leaving rooms.
 - Sending & receiving invites.


### PR DESCRIPTION
As nheko does not support yet sending encrypted attachments (see issue #348) explicitly indicate so in the README.

(NOTE: this was made with GH's interface.... if it looks messy, I'll just do it "the usual way")